### PR TITLE
Fix pre-commit failures on meituan/verl_prefix_tree_full base

### DIFF
--- a/tests/utils/test_prefix_tree_magi.py
+++ b/tests/utils/test_prefix_tree_magi.py
@@ -17,15 +17,15 @@ These tests exercise build_prefix_tree_micro_batch (without the MAGI key
 construction, which requires GPU + distributed) and restore_flat_to_nested.
 All prefix-tree utilities now live in verl.utils — no Megatron-LM fork needed.
 """
+
 from __future__ import annotations
 
-import pytest
 import torch
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_nested(token_lists: list[list[int]], device="cpu") -> torch.Tensor:
     """Build a jagged NestedTensor from a list of token ID lists."""
@@ -41,6 +41,7 @@ def _make_nested_float(value_lists: list[list[float]], device="cpu") -> torch.Te
 # ---------------------------------------------------------------------------
 # Tests for the core layout helpers (no MAGI key, no model)
 # ---------------------------------------------------------------------------
+
 
 class TestBuildPrefixTreeLayout:
     """Tests that verify the flat layout and PrefixTreeParams fields.
@@ -107,12 +108,12 @@ class TestBuildPrefixTreeLayout:
         # (3,5)→(3,5) causal  — leaf_0 self
         # (5,6)→(0,3) full    — leaf_1 attends to prefix
         # (5,6)→(5,6) causal  — leaf_1 self
-        rects = set(zip(params.q_ranges, params.k_ranges, params.mask_types))
-        assert ((0, 3), (0, 3), 'causal') in rects
-        assert ((3, 5), (0, 3), 'full') in rects
-        assert ((3, 5), (3, 5), 'causal') in rects
-        assert ((5, 6), (0, 3), 'full') in rects
-        assert ((5, 6), (5, 6), 'causal') in rects
+        rects = set(zip(params.q_ranges, params.k_ranges, params.mask_types, strict=False))
+        assert ((0, 3), (0, 3), "causal") in rects
+        assert ((3, 5), (0, 3), "full") in rects
+        assert ((3, 5), (3, 5), "causal") in rects
+        assert ((5, 6), (0, 3), "full") in rects
+        assert ((5, 6), (5, 6), "causal") in rects
         assert len(rects) == 5
 
 
@@ -120,13 +121,14 @@ class TestBuildPrefixTreeLayout:
 # Tests for restore_flat_to_nested
 # ---------------------------------------------------------------------------
 
+
 class TestRestoreFlatToNested:
     """Tests that verify round-trip: build params → restore → original tensors."""
 
     def _build_pt_batch(self, tokens, prefix_len):
         """Build a PrefixTreeMagiBatch stub without the MAGI key."""
-        from verl.utils.prefix_tree_utils import build_prefix_tree_params
         from verl.utils.prefix_tree_magi import PrefixTreeMagiBatch
+        from verl.utils.prefix_tree_utils import build_prefix_tree_params
 
         params = build_prefix_tree_params(tokens, prefix_len=prefix_len)
         return PrefixTreeMagiBatch(
@@ -209,14 +211,14 @@ class TestRestoreFlatToNested:
 
     def test_custom_sample_indices(self):
         """sample_indices remapping: leaf_to_sample=[1,0] → restored in index order."""
-        from verl.utils.prefix_tree_utils import build_prefix_tree_params
         from verl.utils.prefix_tree_magi import PrefixTreeMagiBatch, restore_flat_to_nested
+        from verl.utils.prefix_tree_utils import build_prefix_tree_params
 
         # sample_indices=[1,0] means the first token list maps to sample 1,
         # and the second maps to sample 0.
         tokens = [
             torch.tensor([10, 20, 30, 41, 42]),  # → sample 1
-            torch.tensor([10, 20, 30, 51]),       # → sample 0
+            torch.tensor([10, 20, 30, 51]),  # → sample 0
         ]
         params = build_prefix_tree_params(tokens, prefix_len=3, sample_indices=[1, 0])
         pt_batch = PrefixTreeMagiBatch(
@@ -249,6 +251,7 @@ class TestRestoreFlatToNested:
 # ---------------------------------------------------------------------------
 # Integration: NestedTensor input → flat layout (no MAGI key)
 # ---------------------------------------------------------------------------
+
 
 class TestNestedTensorUnpack:
     """Tests that build_prefix_tree_micro_batch correctly unpacks NestedTensors."""
@@ -291,6 +294,7 @@ class TestNestedTensorUnpack:
 
     def test_no_shared_prefix_returns_none(self, monkeypatch):
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         class FakeModel:
@@ -299,6 +303,7 @@ class TestNestedTensorUnpack:
                 num_query_groups = 8
                 kv_channels = 128
                 fp8 = None
+
             pre_process = True
             post_process = True
 
@@ -311,6 +316,7 @@ class TestNestedTensorUnpack:
     def test_loss_mask_flattened(self, monkeypatch):
         """loss_mask NestedTensor is correctly flattened into flat_loss_mask."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         class FakeModel:
@@ -319,6 +325,7 @@ class TestNestedTensorUnpack:
                 num_query_groups = 8
                 kv_channels = 128
                 fp8 = None
+
             pre_process = True
             post_process = True
 
@@ -343,12 +350,14 @@ class TestNestedTensorUnpack:
 # Tests for prefix_segments prior-knowledge path
 # ---------------------------------------------------------------------------
 
+
 class TestPrefixSegmentsPrior:
     """Tests for the fast hash-based prefix detection path."""
 
     def _make_segments(self, token_lists: list[list[int]]) -> list[list[tuple[int, int]]]:
         """Build ground-truth prefix_segments for a list of token sequences."""
         from verl.utils.prefix_tree_magi import _hash_prefix
+
         result = []
         for tokens in token_lists:
             segs = []
@@ -365,13 +374,16 @@ class TestPrefixSegmentsPrior:
                 num_query_groups = 8
                 kv_channels = 128
                 fp8 = None
+
             pre_process = True
             post_process = True
+
         return FakeModel()
 
     def test_prior_matches_scan(self, monkeypatch):
         """Prior-knowledge path returns same prefix_len as the token-scan path."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         token_lists = [[10, 20, 30, 41, 42], [10, 20, 30, 51]]
@@ -380,12 +392,8 @@ class TestPrefixSegmentsPrior:
         # Build segments that exactly match turn boundaries at every token.
         segs = self._make_segments(token_lists)
 
-        result_prior = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids, prefix_segments_batch=segs
-        )
-        result_scan = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids
-        )
+        result_prior = ptm.build_prefix_tree_micro_batch(self._fake_model(), input_ids, prefix_segments_batch=segs)
+        result_scan = ptm.build_prefix_tree_micro_batch(self._fake_model(), input_ids)
 
         assert result_prior is not None
         assert result_scan is not None
@@ -395,6 +403,7 @@ class TestPrefixSegmentsPrior:
     def test_prior_uses_coarsest_shared_boundary(self, monkeypatch):
         """Prior with turn-level segments finds the longest sub-turn boundary."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         from verl.utils.prefix_tree_magi import _hash_prefix
@@ -409,7 +418,8 @@ class TestPrefixSegmentsPrior:
 
         input_ids = _make_nested([[10, 20, 30, 41, 42], [10, 20, 30, 51]])
         result = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids,
+            self._fake_model(),
+            input_ids,
             prefix_segments_batch=[segs0, segs1],
         )
         assert result is not None
@@ -419,20 +429,20 @@ class TestPrefixSegmentsPrior:
     def test_prior_fallback_on_missing(self, monkeypatch):
         """When prefix_segments_batch is None, the scan path is used."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         token_lists = [[10, 20, 30, 41, 42], [10, 20, 30, 51]]
         input_ids = _make_nested(token_lists)
 
-        result = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids, prefix_segments_batch=None
-        )
+        result = ptm.build_prefix_tree_micro_batch(self._fake_model(), input_ids, prefix_segments_batch=None)
         assert result is not None
         assert result.prefix_range == (0, 3)
 
     def test_prior_no_shared_entry_returns_none(self, monkeypatch):
         """When no hash is shared across all samples, returns None (no prefix)."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         from verl.utils.prefix_tree_magi import _hash_prefix
@@ -444,7 +454,8 @@ class TestPrefixSegmentsPrior:
 
         input_ids = _make_nested([[1, 2, 3], [4, 5, 6]])
         result = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids,
+            self._fake_model(),
+            input_ids,
             prefix_segments_batch=[segs0, segs1],
         )
         assert result is None
@@ -452,14 +463,13 @@ class TestPrefixSegmentsPrior:
     def test_prior_after_shuffle(self, monkeypatch):
         """Hash lookup still finds the correct prefix after index reordering."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
-        from verl.utils.prefix_tree_magi import _hash_prefix
-
         token_lists = [
-            [10, 20, 30, 41],   # sample 0
-            [10, 20, 30, 51],   # sample 1
-            [10, 20, 30, 61],   # sample 2
+            [10, 20, 30, 41],  # sample 0
+            [10, 20, 30, 51],  # sample 1
+            [10, 20, 30, 61],  # sample 2
         ]
         segs = self._make_segments(token_lists)
 
@@ -469,7 +479,8 @@ class TestPrefixSegmentsPrior:
         input_ids = _make_nested(shuffled_tokens)
 
         result = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids,
+            self._fake_model(),
+            input_ids,
             prefix_segments_batch=shuffled_segs,
         )
         assert result is not None
@@ -477,7 +488,7 @@ class TestPrefixSegmentsPrior:
 
     def test_build_prefix_segments_single_turn(self):
         """build_prefix_segments_single_turn produces a one-entry list."""
-        from verl.utils.prefix_tree_magi import build_prefix_segments_single_turn, _hash_prefix
+        from verl.utils.prefix_tree_magi import _hash_prefix, build_prefix_segments_single_turn
 
         ids = torch.tensor([1, 2, 3, 4, 5], dtype=torch.long)
         segs = build_prefix_segments_single_turn(ids)
@@ -488,7 +499,7 @@ class TestPrefixSegmentsPrior:
 
     def test_build_prefix_segments_single_turn_with_mask(self):
         """Padding tokens are excluded when attention_mask is provided."""
-        from verl.utils.prefix_tree_magi import build_prefix_segments_single_turn, _hash_prefix
+        from verl.utils.prefix_tree_magi import _hash_prefix, build_prefix_segments_single_turn
 
         ids = torch.tensor([1, 2, 3, 0, 0], dtype=torch.long)
         mask = torch.tensor([1, 1, 1, 0, 0], dtype=torch.long)

--- a/verl/models/mcore/magi_patch.py
+++ b/verl/models/mcore/magi_patch.py
@@ -1,9 +1,23 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Backward-compatibility shim — use prefix_tree_merge instead."""
+
 from verl.models.mcore.prefix_tree_merge import (  # noqa: F401
-    apply_prefix_tree_patch,
-    apply_magi_patch,
-    _magi_attn_forward,
     _flex_attn_forward,
     _layer_capture,
     _layer_counter,
+    _magi_attn_forward,
+    apply_magi_patch,
+    apply_prefix_tree_patch,
 )

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -18,6 +18,7 @@ from typing import Optional
 import torch
 from torch.nested._internal.nested_tensor import NestedTensor
 
+from verl.utils.device import get_torch_device
 from verl.utils.megatron_utils import unwrap_model
 from verl.workers.config import MtpConfig
 
@@ -210,8 +211,6 @@ def _convert_to_nested_tensor(v, input_ids_lengths):
     return v
 
 
-
-
 def gptmodel_forward_model_engine(
     model,
     input_ids,
@@ -246,6 +245,7 @@ def gptmodel_forward_model_engine(
 
     batch_size = input_ids.shape[0]
     import time as _time
+
     import torch.distributed as _dist
 
     if data_format == "thd":
@@ -257,27 +257,28 @@ def gptmodel_forward_model_engine(
         pt_batch = None
         if use_prefix_tree and not vision_model and not mtp_enable_train:
             from verl.utils.prefix_tree_magi import (
-                PrefixTreeMagiBatch,
                 build_prefix_tree_micro_batch,
                 restore_flat_to_nested,
             )
+
             loss_mask_nested = (logits_processor_args or {}).get("loss_mask", None)
             prefix_segments_batch = (logits_processor_args or {}).get("prefix_segments_batch", None)
             # prefix_segments_batch may be a numpy object array or NonTensorStack; convert to list of lists.
             if prefix_segments_batch is not None:
                 import numpy as _np
+
                 if isinstance(prefix_segments_batch, _np.ndarray):
                     prefix_segments_batch = prefix_segments_batch.tolist()
-                elif hasattr(prefix_segments_batch, '__iter__') and not isinstance(prefix_segments_batch, list):
+                elif hasattr(prefix_segments_batch, "__iter__") and not isinstance(prefix_segments_batch, list):
                     # NonTensorStack from SFTTensorCollator: each element is NonTensorData with .data
-                    prefix_segments_batch = [
-                        el.data if hasattr(el, 'data') else el
-                        for el in prefix_segments_batch
-                    ]
+                    prefix_segments_batch = [el.data if hasattr(el, "data") else el for el in prefix_segments_batch]
             from megatron.core import parallel_state as _mpu
+
             _t0 = _time.perf_counter()
             pt_batch = build_prefix_tree_micro_batch(
-                model, input_ids, loss_mask_nested,
+                model,
+                input_ids,
+                loss_mask_nested,
                 prefix_segments_batch=prefix_segments_batch,
                 attention_type=prefix_tree_attention,
                 tp_size=_mpu.get_tensor_model_parallel_world_size(),
@@ -289,32 +290,36 @@ def gptmodel_forward_model_engine(
                 _flat_tokens = pt_batch.real_tokens
                 _share_ratio = (_full_tokens - _flat_tokens) / _full_tokens if _full_tokens > 0 else 0.0
                 if not _dist.is_initialized() or _dist.get_rank() == 0:
-                    print(f"[PT-TIME] build_micro_batch={(_t1-_t0)*1000:.2f}ms "
-                          f"total_tokens={pt_batch.flat_input_ids.shape[0]} "
-                          f"real_tokens={_flat_tokens} "
-                          f"full_tokens={_full_tokens} "
-                          f"prefix_sharing={_share_ratio:.1%} "
-                          f"attn={prefix_tree_attention}", flush=True)
+                    print(
+                        f"[PT-TIME] build_micro_batch={(_t1 - _t0) * 1000:.2f}ms "
+                        f"total_tokens={pt_batch.flat_input_ids.shape[0]} "
+                        f"real_tokens={_flat_tokens} "
+                        f"full_tokens={_full_tokens} "
+                        f"prefix_sharing={_share_ratio:.1%} "
+                        f"attn={prefix_tree_attention}",
+                        flush=True,
+                    )
             if pt_batch is None:
                 if not _dist.is_initialized() or _dist.get_rank() == 0:
                     # Diagnose why prefix-tree returned None
-                    _bs = input_ids.shape[0] if hasattr(input_ids, 'shape') else len(input_ids)
+                    _bs = input_ids.shape[0] if hasattr(input_ids, "shape") else len(input_ids)
                     _segs = prefix_segments_batch[:2] if prefix_segments_batch is not None else None
                 use_prefix_tree = False  # no shared prefix — fall through
 
         # MEM_DUMP: start recording before forward if requested
         import os as _os
-        _mem_tag = _os.environ.get('MEM_DUMP_TAG', '')
-        _mem_dir = _os.environ.get('MEM_DUMP_DIR', '/tmp/claude')
+
+        _mem_tag = _os.environ.get("MEM_DUMP_TAG", "")
+        _mem_dir = _os.environ.get("MEM_DUMP_DIR", "/tmp/claude")
         _mem_rank0 = True  # only rank 0
         try:
             import torch.distributed as _dist
+
             _mem_rank0 = not _dist.is_initialized() or _dist.get_rank() == 0
         except Exception:
             pass
         if _mem_tag and _mem_rank0:
-            import torch as _t
-            _t.cuda.memory._record_memory_history(max_entries=50_000)
+            get_torch_device().memory._record_memory_history(max_entries=50_000)
 
         if use_prefix_tree and pt_batch is not None:
             # Flat token layout — pass full flat tokens to model.
@@ -332,9 +337,9 @@ def gptmodel_forward_model_engine(
                     logits_processor_args.pop(_k)
 
             _tf0 = _time.perf_counter()
-            torch.cuda.synchronize()
-            torch.cuda.reset_peak_memory_stats()
-            _mem_before = torch.cuda.memory_allocated() / 1024**2
+            get_torch_device().synchronize()
+            get_torch_device().reset_peak_memory_stats()
+            _mem_before = get_torch_device().memory_allocated() / 1024**2
             if prefix_tree_attention == "magi":
                 output_orig = model(
                     input_ids=flat_input_ids,
@@ -353,43 +358,52 @@ def gptmodel_forward_model_engine(
                     flex_attention_key=pt_batch.flex_key,
                     **model_kwargs,
                 )
-            torch.cuda.synchronize()
+            get_torch_device().synchronize()
             _tf1 = _time.perf_counter()
             if not _dist.is_initialized() or _dist.get_rank() == 0:
-                _peak_mb = torch.cuda.max_memory_allocated() / 1024**2
-                _alloc_mb = torch.cuda.memory_allocated() / 1024**2
-                print(f"[PT-TIME] model_fwd={(_tf1-_tf0)*1000:.2f}ms peak_mem={_peak_mb:.0f}MB prefix_sharing={_share_ratio:.1%} attn={prefix_tree_attention}", flush=True)
+                _peak_mb = get_torch_device().max_memory_allocated() / 1024**2
+                _alloc_mb = get_torch_device().memory_allocated() / 1024**2
+                print(
+                    f"[PT-TIME] model_fwd={(_tf1 - _tf0) * 1000:.2f}ms "
+                    f"peak_mem={_peak_mb:.0f}MB prefix_sharing={_share_ratio:.1%} "
+                    f"attn={prefix_tree_attention}",
+                    flush=True,
+                )
 
             if post_process and logits_processor is not None:
                 # Strip TP padding (added for sequence-parallel divisibility).
                 real_tokens = pt_batch.real_tokens
                 if output_orig.shape[0] == 1:
-                    output_orig = output_orig[:, :real_tokens]       # (1, real_tokens, vocab)
+                    output_orig = output_orig[:, :real_tokens]  # (1, real_tokens, vocab)
                 else:
                     output_orig = output_orig[:real_tokens].permute(1, 0, 2)  # (1, real_tokens, vocab)
-
 
                 # Transpose to THD: vocab_parallel_cross_entropy expects (total_tokens, batch, vocab)
                 output_orig_thd = output_orig.squeeze(0).unsqueeze(1)  # (real_tokens, 1, vocab)
 
-                import os as _os2, torch.distributed as _dist2
-                _save_cp2 = _os2.environ.get('SAVE_CP_TENSORS') == '1'
-                _cp_rank2 = _dist2.get_rank() if _dist2.is_initialized() else 0
-                _save_dir2 = _os2.environ.get('CP_TENSOR_DIR', '/tmp/claude/cp_tensors')
-                def _save2(name, tensor):
-                    if not _save_cp2: return
-                    _os2.makedirs(_save_dir2, exist_ok=True)
-                    path = f'{_save_dir2}/{name}_rank{_cp_rank2}.pt'
-                    torch.save(tensor.detach().cpu(), path)
-                    print(f'[CP_SAVE] {name} shape={tuple(tensor.shape)} rank={_cp_rank2} → {path}', flush=True)
+                import os as _os2
 
-                _save2('model_forward_output_logits', output_orig_thd)
+                import torch.distributed as _dist2
+
+                _save_cp2 = _os2.environ.get("SAVE_CP_TENSORS") == "1"
+                _cp_rank2 = _dist2.get_rank() if _dist2.is_initialized() else 0
+                _save_dir2 = _os2.environ.get("CP_TENSOR_DIR", "/tmp/claude/cp_tensors")
+
+                def _save2(name, tensor):
+                    if not _save_cp2:
+                        return
+                    _os2.makedirs(_save_dir2, exist_ok=True)
+                    path = f"{_save_dir2}/{name}_rank{_cp_rank2}.pt"
+                    torch.save(tensor.detach().cpu(), path)
+                    print(f"[CP_SAVE] {name} shape={tuple(tensor.shape)} rank={_cp_rank2} → {path}", flush=True)
+
+                _save2("model_forward_output_logits", output_orig_thd)
 
                 # Shift labels by -1 for next-token prediction (same as preprocess_thd_engine)
-                flat_label = torch.roll(
-                    pt_batch.flat_input_ids[:real_tokens], shifts=-1, dims=0
-                ).unsqueeze(1)  # (real_tokens, 1)
-                _save2('model_forward_flat_label', flat_label.squeeze(1))
+                flat_label = torch.roll(pt_batch.flat_input_ids[:real_tokens], shifts=-1, dims=0).unsqueeze(
+                    1
+                )  # (real_tokens, 1)
+                _save2("model_forward_flat_label", flat_label.squeeze(1))
                 orig_args = logits_processor_args or {}
                 total_tokens = flat_label.shape[0]
                 # temperature in THD: (total_tokens, 1)
@@ -401,14 +415,14 @@ def gptmodel_forward_model_engine(
                         scalar_t = t.flatten()[0].item()
                     else:
                         scalar_t = float(t)
-                    flat_t = torch.full((total_tokens, 1), scalar_t,
-                                        dtype=torch.float32, device=flat_label.device)
+                    flat_t = torch.full((total_tokens, 1), scalar_t, dtype=torch.float32, device=flat_label.device)
                 else:
-                    flat_t = torch.ones(total_tokens, 1,
-                                        dtype=torch.float32, device=flat_label.device)
-                flat_args = {k: v for k, v in orig_args.items()
-                             if k not in ("label", "temperature", "loss_mask",
-                                          "use_prefix_tree", "prefix_segments_batch")}
+                    flat_t = torch.ones(total_tokens, 1, dtype=torch.float32, device=flat_label.device)
+                flat_args = {
+                    k: v
+                    for k, v in orig_args.items()
+                    if k not in ("label", "temperature", "loss_mask", "use_prefix_tree", "prefix_segments_batch")
+                }
                 flat_args["label"] = flat_label
                 flat_args["temperature"] = flat_t
                 output_dict = logits_processor(output_orig_thd, **flat_args)
@@ -417,18 +431,21 @@ def gptmodel_forward_model_engine(
                 if isinstance(output_dict, dict) and "log_probs" in output_dict:
                     # log_probs shape: (1, T) — batch-first from vocab_parallel_log_probs_from_logits
                     lp_flat = output_dict["log_probs"].reshape(-1)[:real_tokens]  # (real_tokens,)
-                    _save2('before_restore_log_probs_flat', lp_flat)
+                    _save2("before_restore_log_probs_flat", lp_flat)
                     output_dict["log_probs"] = restore_flat_to_nested(lp_flat, pt_batch)
                     # save per-sample log_probs after restore
                     _nested = output_dict["log_probs"]
-                    if hasattr(_nested, 'values'):
-                        _save2('after_restore_log_probs_flat', _nested.values())
+                    if hasattr(_nested, "values"):
+                        _save2("after_restore_log_probs_flat", _nested.values())
                 output = output_dict
             else:
                 # Strip TP padding before restoring
                 real_tokens = pt_batch.real_tokens
-                out_stripped = output_orig[:, :real_tokens].squeeze(0) \
-                    if output_orig.shape[0] == 1 else output_orig[:real_tokens].squeeze(1)
+                out_stripped = (
+                    output_orig[:, :real_tokens].squeeze(0)
+                    if output_orig.shape[0] == 1
+                    else output_orig[:real_tokens].squeeze(1)
+                )
                 output = restore_flat_to_nested(out_stripped, pt_batch)
 
         else:
@@ -474,19 +491,21 @@ def gptmodel_forward_model_engine(
                 input_ids_rmpad, attention_mask = build_vlm_attn_mask_thd(input_ids, pad_token_id)
 
             _tfa0 = _time.perf_counter()
-            torch.cuda.synchronize()
+            get_torch_device().synchronize()
             output_orig = model(
                 input_ids=input_ids_rmpad,
                 attention_mask=attention_mask,
-                position_ids=position_ids_rmpad if not vision_model else None,  # vision models will calculate position_ids
+                position_ids=position_ids_rmpad
+                if not vision_model
+                else None,  # vision models will calculate position_ids
                 packed_seq_params=packed_seq_params,
                 **model_kwargs,
             )
-            torch.cuda.synchronize()
+            get_torch_device().synchronize()
             _tfa1 = _time.perf_counter()
             if not _dist.is_initialized() or _dist.get_rank() == 0:
-                _peak_mb = torch.cuda.max_memory_allocated() / 1024**2
-                print(f"[FA3-TIME] model_fwd={(_tfa1-_tfa0)*1000:.2f}ms peak_mem={_peak_mb:.0f}MB", flush=True)
+                _peak_mb = get_torch_device().max_memory_allocated() / 1024**2
+                print(f"[FA3-TIME] model_fwd={(_tfa1 - _tfa0) * 1000:.2f}ms peak_mem={_peak_mb:.0f}MB", flush=True)
 
             if post_process and logits_processor is not None:
                 args = {
@@ -499,36 +518,51 @@ def gptmodel_forward_model_engine(
                     )[0]
                     for k, v in logits_processor_args.items()
                 }
-                import os as _os3, torch.distributed as _dist3
-                _save_cp3 = _os3.environ.get('SAVE_CP_TENSORS') == '1'
+                import os as _os3
+
+                import torch.distributed as _dist3
+
+                _save_cp3 = _os3.environ.get("SAVE_CP_TENSORS") == "1"
                 _cp_rank3 = _dist3.get_rank() if _dist3.is_initialized() else 0
-                _save_dir3 = _os3.environ.get('CP_TENSOR_DIR', '/tmp/claude/cp_tensors')
+                _save_dir3 = _os3.environ.get("CP_TENSOR_DIR", "/tmp/claude/cp_tensors")
+
                 def _save3(name, tensor):
-                    if not _save_cp3: return
+                    if not _save_cp3:
+                        return
                     _os3.makedirs(_save_dir3, exist_ok=True)
-                    path = f'{_save_dir3}/{name}_rank{_cp_rank3}.pt'
-                    if _os3.path.exists(path): return  # only save first forward pass
+                    path = f"{_save_dir3}/{name}_rank{_cp_rank3}.pt"
+                    if _os3.path.exists(path):
+                        return  # only save first forward pass
                     torch.save(tensor.detach().cpu(), path)
-                    print(f'[CP_SAVE] {name} shape={tuple(tensor.shape)} rank={_cp_rank3} → {path}', flush=True)
+                    print(f"[CP_SAVE] {name} shape={tuple(tensor.shape)} rank={_cp_rank3} → {path}", flush=True)
+
                 # output_orig shape: (T, 1, vocab) in THD
-                _save3('model_forward_output_logits', output_orig)
-                if 'label' in args:
-                    _save3('model_forward_flat_label', args['label'].squeeze(1) if args['label'].dim() == 2 else args['label'])
+                _save3("model_forward_output_logits", output_orig)
+                if "label" in args:
+                    _save3(
+                        "model_forward_flat_label",
+                        args["label"].squeeze(1) if args["label"].dim() == 2 else args["label"],
+                    )
                 output_dict = logits_processor(output_orig, **args)
-                if isinstance(output_dict, dict) and 'log_probs' in output_dict:
-                    _lp = output_dict['log_probs']
+                if isinstance(output_dict, dict) and "log_probs" in output_dict:
+                    _lp = output_dict["log_probs"]
                     if isinstance(_lp, torch.Tensor) and not _lp.is_nested:
-                        _save3('before_restore_log_probs_flat', _lp.reshape(-1))
+                        _save3("before_restore_log_probs_flat", _lp.reshape(-1))
                 output = {
                     k: postprocess_thd_engine(
-                        v, packed_seq_params, input_ids, batch_size, post_process=post_process, local_cp_size=local_cp_size
+                        v,
+                        packed_seq_params,
+                        input_ids,
+                        batch_size,
+                        post_process=post_process,
+                        local_cp_size=local_cp_size,
                     )
                     for k, v in output_dict.items()
                 }
-                if isinstance(output, dict) and 'log_probs' in output:
-                    _lp_post = output['log_probs']
+                if isinstance(output, dict) and "log_probs" in output:
+                    _lp_post = output["log_probs"]
                     if isinstance(_lp_post, torch.Tensor) and not _lp_post.is_nested:
-                        _save3('after_restore_log_probs_flat', _lp_post.flatten())
+                        _save3("after_restore_log_probs_flat", _lp_post.flatten())
             else:
                 output = postprocess_thd_engine(
                     output_orig,
@@ -607,17 +641,19 @@ def gptmodel_forward_model_engine(
 
     # MEM_DUMP: save snapshot after first forward pass
     if _mem_tag and _mem_rank0:
-        import torch as _t, os as _os
-        snap_path = _os.path.join(_mem_dir, f'{_mem_tag}_snapshot.pickle')
+        import os as _os
+
+        _dev = get_torch_device()
+        snap_path = _os.path.join(_mem_dir, f"{_mem_tag}_snapshot.pickle")
         if not _os.path.exists(snap_path):  # only first call
-            _t.cuda.memory._dump_snapshot(snap_path)
-            peak_mb = _t.cuda.max_memory_allocated() / 1e6
-            summ_path = _os.path.join(_mem_dir, f'{_mem_tag}_mem_summary.txt')
-            with open(summ_path, 'w') as _f:
+            _dev.memory._dump_snapshot(snap_path)
+            peak_mb = _dev.max_memory_allocated() / 1e6
+            summ_path = _os.path.join(_mem_dir, f"{_mem_tag}_mem_summary.txt")
+            with open(summ_path, "w") as _f:
                 _f.write(f"tag={_mem_tag}\n")
                 _f.write(f"peak_allocated_MB={peak_mb:.1f}\n")
-                _f.write(_t.cuda.memory_summary())
+                _f.write(_dev.memory_summary())
             print(f"[MEM_DUMP] {_mem_tag}: peak={peak_mb:.1f}MB → {snap_path}", flush=True)
-        _t.cuda.memory._record_memory_history(enabled=None)
+        _dev.memory._record_memory_history(enabled=None)
 
     return output

--- a/verl/models/mcore/prefix_tree_merge.py
+++ b/verl/models/mcore/prefix_tree_merge.py
@@ -30,20 +30,22 @@ Patch chain (each wrapper accepts ``magi_attention_key``/``flex_attention_key`` 
 The ``_magi_attn_forward`` helper (dispatch → calc_attn → undispatch) is copied
 verbatim from the fork and lives here so no Megatron source modification is needed.
 """
+
 from __future__ import annotations
 
 import functools
 import threading
-from typing import Optional
 
 import torch
 from torch import Tensor
 
+from verl.utils.device import get_torch_device
+
 # Module-level capture state for COMPARE_LAYERS=1 debugging
 _layer_capture: dict = {}
-_layer_counter: dict = {'magi': 0, 'flex': 0, 'fa': 0}  # per-attn-type layer counters
-_current_layer_idx: list = [-1]   # set by _sa_forward, read by _magi_attn_forward
-_current_attn_type: list = ['fa']  # set by _sa_forward, read by _magi_attn_forward
+_layer_counter: dict = {"magi": 0, "flex": 0, "fa": 0}  # per-attn-type layer counters
+_current_layer_idx: list = [-1]  # set by _sa_forward, read by _magi_attn_forward
+_current_attn_type: list = ["fa"]  # set by _sa_forward, read by _magi_attn_forward
 # When COMPARE_LAYERS=2, save full hidden state tensors (not just stats)
 _layer_tensors: dict = {}  # key -> Tensor on CPU
 
@@ -58,6 +60,7 @@ _magi_rope_bypass: threading.local = threading.local()
 # ---------------------------------------------------------------------------
 # flex_attention helper for prefix-tree
 # ---------------------------------------------------------------------------
+
 
 def _flex_attn_forward(
     query: Tensor,
@@ -76,26 +79,29 @@ def _flex_attn_forward(
     from torch.nn.attention.flex_attention import flex_attention
 
     T, _, H, D = query.shape
-    q = query.squeeze(1).permute(1, 0, 2).unsqueeze(0)   # (1, H, T, D)
+    q = query.squeeze(1).permute(1, 0, 2).unsqueeze(0)  # (1, H, T, D)
     k = key.squeeze(1).permute(1, 0, 2).unsqueeze(0)
     v = value.squeeze(1).permute(1, 0, 2).unsqueeze(0)
-    enable_gqa = (q.shape[1] != k.shape[1])
+    enable_gqa = q.shape[1] != k.shape[1]
 
-    import time as _t; import torch.distributed as _dist
-    torch.cuda.synchronize()
+    import time as _t
+
+    import torch.distributed as _dist
+
+    get_torch_device().synchronize()
     _t0 = _t.perf_counter()
-    out = flex_attention(q, k, v, block_mask=flex_attention_key,
-                         enable_gqa=enable_gqa)  # (1, Hq, T, D)
-    torch.cuda.synchronize()
+    out = flex_attention(q, k, v, block_mask=flex_attention_key, enable_gqa=enable_gqa)  # (1, Hq, T, D)
+    get_torch_device().synchronize()
     if not _dist.is_initialized() or _dist.get_rank() == 0:
-        print(f"[FLEX-ATTN] T={T} {(_t.perf_counter()-_t0)*1000:.2f}ms", flush=True)
+        print(f"[FLEX-ATTN] T={T} {(_t.perf_counter() - _t0) * 1000:.2f}ms", flush=True)
     out = out.squeeze(0).permute(1, 0, 2)  # (T, Hq, D)
-    return out.reshape(T, 1, -1)           # (T, 1, Hq*D)
+    return out.reshape(T, 1, -1)  # (T, 1, Hq*D)
 
 
 # ---------------------------------------------------------------------------
 # MAGI attention kernel helper (verbatim from Megatron-LM-prefix-tree fork)
 # ---------------------------------------------------------------------------
+
 
 def _magi_attn_forward(
     query: Tensor,
@@ -113,39 +119,46 @@ def _magi_attn_forward(
     across TP to get full T tokens, then dispatch/calc_attn/undispatch across
     CP ranks, then scatter back to T/TP for SP-consistent output.
     """
-    from magi_attention.api import calc_attn, dispatch, undispatch
-    import os as _os, torch as _torch, torch.distributed as _dist
+    import os as _os
 
-    q = query.squeeze(1)   # (T, np, hn) — already full T (Megatron gathers SP before calling here)
+    import torch as _torch
+    import torch.distributed as _dist
+    from magi_attention.api import calc_attn, dispatch, undispatch
+
+    q = query.squeeze(1)  # (T, np, hn) — already full T (Megatron gathers SP before calling here)
     k = key.squeeze(1)
     v = value.squeeze(1)
     _gathered = False
 
-    _save_cp = _os.environ.get('SAVE_CP_TENSORS') == '1'
+    _save_cp = _os.environ.get("SAVE_CP_TENSORS") == "1"
     _cp_rank = _dist.get_rank() if _dist.is_initialized() else 0
-    _save_dir = _os.environ.get('CP_TENSOR_DIR', '/tmp/claude/cp_tensors')
+    _save_dir = _os.environ.get("CP_TENSOR_DIR", "/tmp/claude/cp_tensors")
     # Layer index and attn type set by _sa_forward (which owns the counter increment)
     _layer_idx = _current_layer_idx[0]
     _atype = _current_attn_type[0]
 
     def _save(name, tensor):
-        if not _save_cp: return
+        if not _save_cp:
+            return
         _os.makedirs(_save_dir, exist_ok=True)
-        path = f'{_save_dir}/{_atype}_{name}_rank{_cp_rank}_layer{_layer_idx}.pt'
+        path = f"{_save_dir}/{_atype}_{name}_rank{_cp_rank}_layer{_layer_idx}.pt"
         _torch.save(tensor.detach().cpu(), path)
-        print(f'[CP_SAVE] {_atype}_{name} shape={tuple(tensor.shape)} rank={_cp_rank} layer={_layer_idx} → {path}', flush=True)
+        print(
+            f"[CP_SAVE] {_atype}_{name} shape={tuple(tensor.shape)} rank={_cp_rank} layer={_layer_idx} → {path}",
+            flush=True,
+        )
 
     # before_dispatch_Q/K/V saved by _sa_forward wrapper (covers both FA3 and MAGI)
     dq = dispatch(q, magi_attention_key)
     dk = dispatch(k, magi_attention_key)
     dv = dispatch(v, magi_attention_key)
 
-    _save('after_dispatch_Q', dq)
-    _save('after_dispatch_K', dk)
-    _save('after_dispatch_V', dv)
+    _save("after_dispatch_Q", dq)
+    _save("after_dispatch_K", dk)
+    _save("after_dispatch_V", dv)
 
     out, _ = calc_attn(dq, dk, dv, magi_attention_key)
-    _save('after_calc_attn_out', out)
+    _save("after_calc_attn_out", out)
 
     out = undispatch(out, magi_attention_key)
     # after_undispatch_out saved by _sa_forward wrapper
@@ -157,6 +170,7 @@ def _magi_attn_forward(
 # Patch application
 # ---------------------------------------------------------------------------
 
+
 def apply_prefix_tree_patch() -> None:
     """Monkey-patch upstream Megatron-LM classes to support prefix-tree attention (flex and MAGI).
 
@@ -164,10 +178,10 @@ def apply_prefix_tree_patch() -> None:
     ``_magi_patched`` sentinel attribute).
     """
     from megatron.core.extensions.transformer_engine import TEDotProductAttention
-    from megatron.core.transformer.attention import SelfAttention
-    from megatron.core.transformer.transformer_layer import TransformerLayer
-    from megatron.core.transformer.transformer_block import TransformerBlock
     from megatron.core.models.gpt.gpt_model import GPTModel
+    from megatron.core.transformer.attention import SelfAttention
+    from megatron.core.transformer.transformer_block import TransformerBlock
+    from megatron.core.transformer.transformer_layer import TransformerLayer
 
     if getattr(TEDotProductAttention, "_prefix_tree_patched", False):
         return  # already patched
@@ -178,25 +192,47 @@ def apply_prefix_tree_patch() -> None:
     _orig_te_forward = TEDotProductAttention.forward
 
     @functools.wraps(_orig_te_forward)
-    def _te_forward(self, query, key, value, attention_mask, attn_mask_type,
-                    attention_bias=None, packed_seq_params=None, num_splits=None,
-                    magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _te_forward(
+        self,
+        query,
+        key,
+        value,
+        attention_mask,
+        attn_mask_type,
+        attention_bias=None,
+        packed_seq_params=None,
+        num_splits=None,
+        magi_attention_key=None,
+        flex_attention_key=None,
+        **kwargs,
+    ):
         if magi_attention_key is not None:
             return _magi_attn_forward(query, key, value, magi_attention_key)
         if flex_attention_key is not None:
             return _flex_attn_forward(query, key, value, flex_attention_key)
         # FA3 path — Q/K/V and output are saved in _sa_forward via core_attention wrapper
-        import time as _t, torch as _torch, torch.distributed as _dist
-        _torch.cuda.synchronize()
+        import time as _t
+
+        import torch.distributed as _dist
+
+        get_torch_device().synchronize()
         _t0 = _t.perf_counter()
-        out = _orig_te_forward(self, query, key, value, attention_mask, attn_mask_type,
-                               attention_bias=attention_bias,
-                               packed_seq_params=packed_seq_params,
-                               num_splits=num_splits, **kwargs)
-        _torch.cuda.synchronize()
+        out = _orig_te_forward(
+            self,
+            query,
+            key,
+            value,
+            attention_mask,
+            attn_mask_type,
+            attention_bias=attention_bias,
+            packed_seq_params=packed_seq_params,
+            num_splits=num_splits,
+            **kwargs,
+        )
+        get_torch_device().synchronize()
         if not _dist.is_initialized() or _dist.get_rank() == 0:
             T = query.shape[0]
-            print(f"[FA3-ATTN] T={T} {(_t.perf_counter()-_t0)*1000:.2f}ms", flush=True)
+            print(f"[FA3-ATTN] T={T} {(_t.perf_counter() - _t0) * 1000:.2f}ms", flush=True)
         return out
 
     TEDotProductAttention.forward = _te_forward
@@ -207,12 +243,22 @@ def apply_prefix_tree_patch() -> None:
     _orig_sa_ckpt = SelfAttention._checkpointed_attention_forward
 
     @functools.wraps(_orig_sa_ckpt)
-    def _sa_ckpt_forward(self, query, key, value, attention_mask,
-                         rotary_pos_emb=None, attn_mask_type=None,
-                         attention_bias=None, packed_seq_params=None,
-                         magi_attention_key=None, flex_attention_key=None, **kwargs):
-        from megatron.core.transformer.attention import AttnMaskType
+    def _sa_ckpt_forward(
+        self,
+        query,
+        key,
+        value,
+        attention_mask,
+        rotary_pos_emb=None,
+        attn_mask_type=None,
+        attention_bias=None,
+        packed_seq_params=None,
+        magi_attention_key=None,
+        flex_attention_key=None,
+        **kwargs,
+    ):
         from megatron.core.tensor_parallel.random import checkpoint as tensor_parallel_checkpoint
+        from megatron.core.transformer.attention import AttnMaskType
 
         try:
             from megatron.core.transformer.utils import apply_module
@@ -225,7 +271,10 @@ def apply_prefix_tree_patch() -> None:
             # Keys are already injected via _ca_forward_with_key wrapper on self.core_attention
             # (set by _sa_forward before calling _orig_sa_forward). Don't pass them again.
             return apply_module(self.core_attention)(
-                q, k, v, amask,
+                q,
+                k,
+                v,
+                amask,
                 attn_mask_type=_attn_mask_type,
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
@@ -235,8 +284,14 @@ def apply_prefix_tree_patch() -> None:
             attn_mask_type = self.attn_mask_type
         attn_mask_type_tensor = torch.tensor([attn_mask_type.value], dtype=torch.int)
         return tensor_parallel_checkpoint(
-            custom_forward, False,
-            query, key, value, attention_mask, rotary_pos_emb, attn_mask_type_tensor,
+            custom_forward,
+            False,
+            query,
+            key,
+            value,
+            attention_mask,
+            rotary_pos_emb,
+            attn_mask_type_tensor,
         )
 
     SelfAttention._checkpointed_attention_forward = _sa_ckpt_forward
@@ -247,38 +302,50 @@ def apply_prefix_tree_patch() -> None:
     _orig_sa_forward = SelfAttention.forward
 
     @functools.wraps(_orig_sa_forward)
-    def _sa_forward(self, hidden_states, attention_mask,
-                    magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _sa_forward(self, hidden_states, attention_mask, magi_attention_key=None, flex_attention_key=None, **kwargs):
         attn_key = magi_attention_key or flex_attention_key
         _real_ca_forward = self.core_attention.forward
 
-        import os as _os, torch as _torch, torch.distributed as _dist
-        _save_cp = _os.environ.get('SAVE_CP_TENSORS') == '1'
+        import os as _os
+
+        import torch as _torch
+        import torch.distributed as _dist
+
+        _save_cp = _os.environ.get("SAVE_CP_TENSORS") == "1"
         _cp_rank = _dist.get_rank() if _dist.is_initialized() else 0
-        _save_dir = _os.environ.get('CP_TENSOR_DIR', '/tmp/claude/cp_tensors')
-        _atype = 'magi' if magi_attention_key else ('flex' if flex_attention_key else 'fa')
+        _save_dir = _os.environ.get("CP_TENSOR_DIR", "/tmp/claude/cp_tensors")
+        _atype = "magi" if magi_attention_key else ("flex" if flex_attention_key else "fa")
         _layer_idx = _layer_counter[_atype]
         _layer_counter[_atype] += 1
-        _current_layer_idx[0] = _layer_idx   # share with _magi_attn_forward
-        _current_attn_type[0] = _atype        # share with _magi_attn_forward
+        _current_layer_idx[0] = _layer_idx  # share with _magi_attn_forward
+        _current_attn_type[0] = _atype  # share with _magi_attn_forward
 
         def _save_sa(name, tensor):
-            if not _save_cp: return
+            if not _save_cp:
+                return
             _os.makedirs(_save_dir, exist_ok=True)
-            path = f'{_save_dir}/{_atype}_{name}_rank{_cp_rank}_layer{_layer_idx}.pt'
+            path = f"{_save_dir}/{_atype}_{name}_rank{_cp_rank}_layer{_layer_idx}.pt"
             _torch.save(tensor.detach().cpu(), path)
-            print(f'[CP_SAVE] {_atype}_{name} shape={tuple(tensor.shape)} rank={_cp_rank} layer={_layer_idx} → {path}', flush=True)
+            print(
+                f"[CP_SAVE] {_atype}_{name} shape={tuple(tensor.shape)} rank={_cp_rank} layer={_layer_idx} → {path}",
+                flush=True,
+            )
 
         @functools.wraps(_real_ca_forward)
         def _ca_forward_with_key(q, k, v, *args, **kw):
-            _save_sa('before_dispatch_Q', q.squeeze(1) if q.dim() == 4 else q)
-            _save_sa('before_dispatch_K', k.squeeze(1) if k.dim() == 4 else k)
-            _save_sa('before_dispatch_V', v.squeeze(1) if v.dim() == 4 else v)
-            out = _real_ca_forward(q, k, v, *args,
-                                   magi_attention_key=magi_attention_key if attn_key else None,
-                                   flex_attention_key=flex_attention_key if attn_key else None,
-                                   **kw)
-            _save_sa('after_undispatch_out', out.squeeze(1) if out.dim() == 3 else out)
+            _save_sa("before_dispatch_Q", q.squeeze(1) if q.dim() == 4 else q)
+            _save_sa("before_dispatch_K", k.squeeze(1) if k.dim() == 4 else k)
+            _save_sa("before_dispatch_V", v.squeeze(1) if v.dim() == 4 else v)
+            out = _real_ca_forward(
+                q,
+                k,
+                v,
+                *args,
+                magi_attention_key=magi_attention_key if attn_key else None,
+                flex_attention_key=flex_attention_key if attn_key else None,
+                **kw,
+            )
+            _save_sa("after_undispatch_out", out.squeeze(1) if out.dim() == 3 else out)
             return out
 
         self.core_attention.forward = _ca_forward_with_key
@@ -296,8 +363,7 @@ def apply_prefix_tree_patch() -> None:
     _orig_tl_forward = TransformerLayer.forward
 
     @functools.wraps(_orig_tl_forward)
-    def _tl_forward(self, hidden_states, attention_mask,
-                    magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _tl_forward(self, hidden_states, attention_mask, magi_attention_key=None, flex_attention_key=None, **kwargs):
         attn_key = magi_attention_key or flex_attention_key
         if attn_key is None:
             out = _orig_tl_forward(self, hidden_states, attention_mask, **kwargs)
@@ -306,9 +372,9 @@ def apply_prefix_tree_patch() -> None:
 
             @functools.wraps(_real_sa_forward)
             def _sa_forward_with_key(*args, **kw):
-                return _real_sa_forward(*args,
-                                        magi_attention_key=magi_attention_key,
-                                        flex_attention_key=flex_attention_key, **kw)
+                return _real_sa_forward(
+                    *args, magi_attention_key=magi_attention_key, flex_attention_key=flex_attention_key, **kw
+                )
 
             self.self_attention.forward = _sa_forward_with_key
             try:
@@ -318,14 +384,15 @@ def apply_prefix_tree_patch() -> None:
 
         # COMPARE_LAYERS: capture forward hidden state + backward gradient per layer
         import os as _os
-        _cl = _os.environ.get('COMPARE_LAYERS', '0')
-        if _cl in ('1', '2'):
+
+        _cl = _os.environ.get("COMPARE_LAYERS", "0")
+        if _cl in ("1", "2"):
             import torch.distributed as _dist
+
             hs_out = out[0] if isinstance(out, tuple) else out
             idx = _layer_counter[0]
-            tag = 'flex' if flex_attention_key is not None else \
-                  'magi' if magi_attention_key is not None else 'fa3'
-            key = f'{tag}_{idx}'
+            tag = "flex" if flex_attention_key is not None else "magi" if magi_attention_key is not None else "fa3"
+            key = f"{tag}_{idx}"
             # Only capture every 5 layers (0, 5, 10, ...) to see trend without huge files
             _layer_counter[0] += 1
             if idx % 5 != 0 or key in _layer_capture:
@@ -337,11 +404,12 @@ def apply_prefix_tree_patch() -> None:
                 if _dist.is_initialized():
                     try:
                         from megatron.core import mpu
+
                         tp_group = mpu.get_tensor_model_parallel_group()
-                        tp_size  = mpu.get_tensor_model_parallel_world_size()
+                        tp_size = mpu.get_tensor_model_parallel_world_size()
                     except Exception:
                         tp_group = None
-                        tp_size  = _dist.get_world_size()
+                        tp_size = _dist.get_world_size()
                     gathered = [torch.zeros_like(h_local) for _ in range(tp_size)]
                     _dist.all_gather(gathered, h_local, group=tp_group)
                     h = torch.cat(gathered, dim=0)  # (T_full, 1, H)
@@ -349,26 +417,29 @@ def apply_prefix_tree_patch() -> None:
                     h = h_local
                 if not _dist.is_initialized() or _dist.get_rank() == 0:
                     _layer_capture[key] = {
-                        'fwd_mean': h.mean().item(),
-                        'fwd_std':  h.std().item(),
-                        'fwd_norm': h.norm().item(),
-                        'shape': list(h.shape),
+                        "fwd_mean": h.mean().item(),
+                        "fwd_std": h.std().item(),
+                        "fwd_norm": h.norm().item(),
+                        "shape": list(h.shape),
                     }
                     # COMPARE_LAYERS=2: also save full tensor to disk for per-token diff
-                    if _cl == '2':
+                    if _cl == "2":
                         _layer_tensors[key] = h.cpu()
                     # Capture gradient via retain_grad + hook
                     _bwd_key = key
-                    def _make_bwd_hook(bk, save_full=(_cl == '2')):
+
+                    def _make_bwd_hook(bk, save_full=(_cl == "2")):
                         def _bwd(grad):
-                            if bk in _layer_capture and 'bwd_norm' not in _layer_capture[bk]:
+                            if bk in _layer_capture and "bwd_norm" not in _layer_capture[bk]:
                                 g = grad.detach().float()
-                                _layer_capture[bk]['bwd_mean'] = g.mean().item()
-                                _layer_capture[bk]['bwd_std']  = g.std().item()
-                                _layer_capture[bk]['bwd_norm'] = g.norm().item()
+                                _layer_capture[bk]["bwd_mean"] = g.mean().item()
+                                _layer_capture[bk]["bwd_std"] = g.std().item()
+                                _layer_capture[bk]["bwd_norm"] = g.norm().item()
                                 if save_full:
-                                    _layer_tensors[bk + '_bwd'] = g.cpu()
+                                    _layer_tensors[bk + "_bwd"] = g.cpu()
+
                         return _bwd
+
                     if hs_out.requires_grad:
                         hs_out.retain_grad()
                         hs_out.register_hook(_make_bwd_hook(_bwd_key))
@@ -382,8 +453,7 @@ def apply_prefix_tree_patch() -> None:
     _orig_tb_forward = TransformerBlock.forward
 
     @functools.wraps(_orig_tb_forward)
-    def _tb_forward(self, hidden_states, attention_mask,
-                    magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _tb_forward(self, hidden_states, attention_mask, magi_attention_key=None, flex_attention_key=None, **kwargs):
         attn_key = magi_attention_key or flex_attention_key
         if attn_key is None:
             return _orig_tb_forward(self, hidden_states, attention_mask, **kwargs)
@@ -395,16 +465,17 @@ def apply_prefix_tree_patch() -> None:
             def _make_wrapper(orig):
                 @functools.wraps(orig)
                 def _w(*args, **kw):
-                    return orig(*args,
-                                magi_attention_key=magi_attention_key,
-                                flex_attention_key=flex_attention_key, **kw)
+                    return orig(
+                        *args, magi_attention_key=magi_attention_key, flex_attention_key=flex_attention_key, **kw
+                    )
+
                 return _w
 
             layer.forward = _make_wrapper(_orig)
         try:
             out = _orig_tb_forward(self, hidden_states, attention_mask, **kwargs)
         finally:
-            for layer, orig_fwd in zip(self.layers, originals):
+            for layer, orig_fwd in zip(self.layers, originals, strict=False):
                 layer.forward = orig_fwd
         return out
 
@@ -418,8 +489,9 @@ def apply_prefix_tree_patch() -> None:
     _orig_gpt_forward = GPTModel.forward
 
     @functools.wraps(_orig_gpt_forward)
-    def _gpt_forward(self, input_ids, position_ids, attention_mask,
-                     magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _gpt_forward(
+        self, input_ids, position_ids, attention_mask, magi_attention_key=None, flex_attention_key=None, **kwargs
+    ):
         attn_key = magi_attention_key or flex_attention_key
         if attn_key is None:
             return _orig_gpt_forward(self, input_ids, position_ids, attention_mask, **kwargs)
@@ -427,12 +499,12 @@ def apply_prefix_tree_patch() -> None:
 
         @functools.wraps(_real_decoder_forward)
         def _decoder_forward_with_key(*args, **kw):
-            return _real_decoder_forward(*args,
-                                         magi_attention_key=magi_attention_key,
-                                         flex_attention_key=flex_attention_key, **kw)
+            return _real_decoder_forward(
+                *args, magi_attention_key=magi_attention_key, flex_attention_key=flex_attention_key, **kw
+            )
 
         self.decoder.forward = _decoder_forward_with_key
-        _prev_rope_bypass = getattr(_magi_rope_bypass, 'active', False)
+        _prev_rope_bypass = getattr(_magi_rope_bypass, "active", False)
         _magi_rope_bypass.active = True  # all prefix-tree paths bypass CP RoPE slicing
         try:
             out = _orig_gpt_forward(self, input_ids, position_ids, attention_mask, **kwargs)
@@ -456,20 +528,20 @@ def apply_prefix_tree_patch() -> None:
     # in BSHD attention, so correctness is maintained regardless of CP rank.
     # ------------------------------------------------------------------
     from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
-    _orig_rope_cached = RotaryEmbedding.forward           # lru_cache wrapper
-    _orig_rope_fn = RotaryEmbedding.forward.__wrapped__   # actual function body
+
+    _orig_rope_cached = RotaryEmbedding.forward  # lru_cache wrapper
+    _orig_rope_fn = RotaryEmbedding.forward.__wrapped__  # actual function body
 
     def _rope_forward_pt(self, max_seq_len, offset=0, packed_seq=False, cp_group=None):
-        if getattr(_magi_rope_bypass, 'active', False):
+        if getattr(_magi_rope_bypass, "active", False):
             # Bypass CP slice: return full-sequence freqs identical on all CP ranks.
             # get_rotary_seq_len multiplies by cp_size (yielding 2T for CP=2), so we
             # divide it back out here to get the true flat-sequence length T.
-            _cp = cp_group or getattr(self, 'cp_group', None)
+            _cp = cp_group or getattr(self, "cp_group", None)
             _cp_size = _cp.size() if _cp is not None else 1
             actual_seq_len = max_seq_len // _cp_size
             return _orig_rope_fn(self, actual_seq_len, offset=offset, packed_seq=True, cp_group=None)
-        return _orig_rope_cached(self, max_seq_len, offset=offset,
-                                 packed_seq=packed_seq, cp_group=cp_group)
+        return _orig_rope_cached(self, max_seq_len, offset=offset, packed_seq=packed_seq, cp_group=cp_group)
 
     RotaryEmbedding.forward = _rope_forward_pt
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1365,6 +1365,7 @@ class RayPPOTrainer:
                     and "input_ids" in gen_batch_output.batch.keys()
                 ):
                     from verl.utils.prefix_tree_magi import build_prefix_segments_single_turn
+
                     _ids = gen_batch_output.batch["input_ids"]
                     _mask = gen_batch_output.batch.get("attention_mask", None)
                     gen_batch_output.non_tensor_batch["prefix_segments"] = np.array(

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -239,7 +239,11 @@ class SFTTrainer:
         dp_size = self.engine.get_data_parallel_size()
 
         self.train_sampler = DistributedSampler(
-            self.train_dataset, shuffle=self.config.data.get("shuffle", True), num_replicas=dp_size, rank=dp_rank, drop_last=True
+            self.train_dataset,
+            shuffle=self.config.data.get("shuffle", True),
+            num_replicas=dp_size,
+            rank=dp_rank,
+            drop_last=True,
         )
 
         self.global_batch_size = config.data.train_batch_size

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -185,8 +185,11 @@ class SFTTrainer:
         dp_size = 1
 
         self.train_sampler = DistributedSampler(
-            self.train_dataset, shuffle=self.config.data.get("shuffle", True),
-            num_replicas=dp_size, rank=dp_rank, drop_last=True
+            self.train_dataset,
+            shuffle=self.config.data.get("shuffle", True),
+            num_replicas=dp_size,
+            rank=dp_rank,
+            drop_last=True,
         )
 
         self.global_batch_size = config.data.train_batch_size

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -36,8 +36,8 @@ from verl.utils.chat_template import apply_chat_template, extract_system_prompt_
 from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.dataset.vision_utils import process_image, process_video
 from verl.utils.fs import copy_local_path_from_hdfs
-from verl.utils.py_functional import convert_nested_value_to_list_recursive
 from verl.utils.prefix_tree_magi import _hash_prefix as _hash_prefix_ids
+from verl.utils.py_functional import convert_nested_value_to_list_recursive
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))

--- a/verl/utils/prefix_tree_magi.py
+++ b/verl/utils/prefix_tree_magi.py
@@ -30,9 +30,9 @@ Usage (inside gptmodel_forward_model_engine):
         )
         output = restore_flat_to_nested(output, pt_batch)
 """
+
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass
 from typing import Optional
 
@@ -46,8 +46,8 @@ class PrefixTreeMagiBatch:
     """Holds the flat layout and MAGI key for one prefix-tree micro-batch."""
 
     # flat input tensors ready to pass to model(...)
-    flat_input_ids: Tensor       # (total_tokens,)
-    flat_position_ids: Tensor    # (total_tokens,)
+    flat_input_ids: Tensor  # (total_tokens,)
+    flat_position_ids: Tensor  # (total_tokens,)
     flat_loss_mask: Optional[Tensor]  # (total_tokens,) or None
 
     # Attention keys — one will be None depending on prefix_tree_attention setting
@@ -124,11 +124,9 @@ def build_prefix_tree_micro_batch(
     Returns:
         PrefixTreeMagiBatch or None.
     """
-    import torch.distributed as dist
 
     from verl.utils.prefix_tree_utils import (
         build_prefix_tree_params,
-        extract_sample_tensors,
         longest_common_prefix_length,
     )
 
@@ -145,13 +143,17 @@ def build_prefix_tree_micro_batch(
 
     # Fast path: use injected prior knowledge when available.
     import os as _os
+
     if prefix_segments_batch is not None and len(prefix_segments_batch) == len(tokens_by_sample):
         prefix_len = _resolve_prefix_len_from_segments(prefix_segments_batch)
-        if _os.environ.get('DEBUG_PREFIX_LEN') == '1':
+        if _os.environ.get("DEBUG_PREFIX_LEN") == "1":
             scan_len = longest_common_prefix_length(tokens_by_sample)
             T = tokens_by_sample[0].shape[0] if tokens_by_sample else 0
-            print(f'[PREFIX_LEN] seg_len={prefix_len} scan_len={scan_len} T={T} '
-                  f'n_segs={[len(s) for s in prefix_segments_batch]}', flush=True)
+            print(
+                f"[PREFIX_LEN] seg_len={prefix_len} scan_len={scan_len} T={T} "
+                f"n_segs={[len(s) for s in prefix_segments_batch]}",
+                flush=True,
+            )
     else:
         prefix_len = longest_common_prefix_length(tokens_by_sample)
 
@@ -187,14 +189,14 @@ def build_prefix_tree_micro_batch(
     if prefix_segments_batch is not None:
         actual_root_len = longest_common_prefix_length(tokens_by_sample)
         if actual_root_len > 0:
-            multilevel_result = _resolve_multilevel_tree(
-                tokens_by_sample, prefix_segments_batch, actual_root_len
-            )
+            multilevel_result = _resolve_multilevel_tree(tokens_by_sample, prefix_segments_batch, actual_root_len)
 
     if multilevel_result is not None:
         root_len, children_info = multilevel_result
         params = _build_multilevel_prefix_tree_params(
-            tokens_by_sample, root_len, children_info,
+            tokens_by_sample,
+            root_len,
+            children_info,
             loss_masks_by_sample=loss_masks_by_sample,
             position_ids_by_sample=position_ids_by_sample,
         )
@@ -216,13 +218,13 @@ def build_prefix_tree_micro_batch(
         pad_len = (align_size - total % align_size) % align_size
         if pad_len > 0:
             import torch as _torch
-            params.flat_tokens = _torch.cat(
-                [params.flat_tokens, params.flat_tokens.new_zeros(pad_len)])
+
+            params.flat_tokens = _torch.cat([params.flat_tokens, params.flat_tokens.new_zeros(pad_len)])
             params.flat_position_ids = _torch.cat(
-                [params.flat_position_ids, params.flat_position_ids.new_zeros(pad_len)])
+                [params.flat_position_ids, params.flat_position_ids.new_zeros(pad_len)]
+            )
             if params.flat_loss_mask is not None:
-                params.flat_loss_mask = _torch.cat(
-                    [params.flat_loss_mask, params.flat_loss_mask.new_zeros(pad_len)])
+                params.flat_loss_mask = _torch.cat([params.flat_loss_mask, params.flat_loss_mask.new_zeros(pad_len)])
             params.total_seqlen_q += pad_len
             params.total_seqlen_k += pad_len
             # Do NOT add rectangles for padding tokens — they are stripped before loss.
@@ -256,7 +258,7 @@ def build_prefix_tree_micro_batch(
         prefix_range=params.prefix_range,
         original_batch_size=params.num_samples,
         real_tokens=real_tokens,
-        leaf_ancestor_ranges=getattr(params, '_leaf_ancestor_ranges', None),
+        leaf_ancestor_ranges=getattr(params, "_leaf_ancestor_ranges", None),
         local_flat_input_ids=local_flat_tokens,
         local_flat_position_ids=local_flat_position_ids,
         local_flat_loss_mask=local_flat_loss_mask,
@@ -320,9 +322,11 @@ def _hash_prefix(token_ids_flat: Tensor) -> int:
     raw = token_ids_flat.numpy().tobytes()
     try:
         import xxhash  # type: ignore[import]
+
         return xxhash.xxh128_intdigest(raw)
     except ImportError:
         import hashlib
+
         return int.from_bytes(hashlib.md5(raw).digest(), "little")
 
 
@@ -374,6 +378,7 @@ def _resolve_multilevel_tree(
     have ≥2 samples, a 2-level tree exists and we return a TreeNode root.
     """
     from collections import defaultdict
+
     from verl.utils.prefix_tree_utils import TreeNode
 
     n = len(tokens_by_sample)
@@ -400,6 +405,7 @@ def _resolve_multilevel_tree(
     # Use token scan (not segment hashes) to get exact turn2 shared prefix length per group.
     # Segment hashes can mis-align due to chat-template boundary effects.
     from verl.utils.prefix_tree_utils import longest_common_prefix_length
+
     children = []
     for _h, idxs in useful:
         group_tokens = [tokens_by_sample[i] for i in idxs]
@@ -409,8 +415,7 @@ def _resolve_multilevel_tree(
         if shared_suffix_len <= 0:
             return None
         group_turn2_len = shared_suffix_len
-        leaves = [TreeNode(int(tokens_by_sample[i].shape[0]) - root_prefix_len - group_turn2_len, [])
-                  for i in idxs]
+        leaves = [TreeNode(int(tokens_by_sample[i].shape[0]) - root_prefix_len - group_turn2_len, []) for i in idxs]
         if any(leaf.segment_len <= 0 for leaf in leaves):
             return None
         children.append((idxs, TreeNode(group_turn2_len, leaves)))
@@ -427,8 +432,9 @@ def _build_multilevel_prefix_tree_params(
 ):
     """Build PrefixTreeParams for a 2-level tree using build_multilevel_flex_spec."""
     import torch
-    from verl.utils.prefix_tree_utils import TreeNode, build_multilevel_flex_spec
+
     from verl.utils.prefix_tree_params import PrefixTreeParams
+    from verl.utils.prefix_tree_utils import TreeNode, build_multilevel_flex_spec
 
     # Build TreeNode for flex_spec
     tree_children = [child_node for _, child_node in children_info]
@@ -442,6 +448,7 @@ def _build_multilevel_prefix_tree_params(
         for child in node.children:
             cur = _assign_offsets(child, cur)
         return cur
+
     total_tokens = _assign_offsets(root_node, 0)
 
     # Build flat token tensor: root + each child group + each leaf in DFS order
@@ -470,21 +477,20 @@ def _build_multilevel_prefix_tree_params(
         # internal node: add this node's own tokens (shared by its group)
         sample_idx = sample_idxs_list[0]
         tok = tokens_by_sample[sample_idx]
-        node_start_in_sample = node._flat_start  # offset in flat layout
         # Compute where this node's tokens start in the original sample
         # For root: sample[0:root_len]
         # For depth-1 child: sample[root_len : root_len + child.segment_len]
         if depth == 0:
-            content = tok[:node._flat_end]  # root tokens
+            content = tok[: node._flat_end]  # root tokens
         else:
-            content = tok[root_len: root_len + node.segment_len]  # turn2 tokens
+            content = tok[root_len : root_len + node.segment_len]  # turn2 tokens
         flat_parts.append(content)
 
         # Recurse into children, distributing sample indices
         leaf_idx = 0
         for child in node.children:
             n_leaves = _count_leaves(child)
-            _flatten_node(child, sample_idxs_list[leaf_idx:leaf_idx + n_leaves], depth + 1)
+            _flatten_node(child, sample_idxs_list[leaf_idx : leaf_idx + n_leaves], depth + 1)
             leaf_idx += n_leaves
 
     def _count_leaves(node):
@@ -502,19 +508,18 @@ def _build_multilevel_prefix_tree_params(
     for child_idxs, child_node in children_info:
         # Add turn2 tokens (from first sample of this group)
         sample0 = child_idxs[0]
-        turn2_tokens = tokens_by_sample[sample0][root_len: root_len + child_node.segment_len]
+        turn2_tokens = tokens_by_sample[sample0][root_len : root_len + child_node.segment_len]
         flat_parts.append(turn2_tokens)
         turn2_flat_start = cur_offset
         cur_offset += child_node.segment_len
         turn2_flat_range = (turn2_flat_start, cur_offset)
 
         # Add each leaf
-        for leaf_node, sample_idx in zip(child_node.children, child_idxs):
+        for leaf_node, sample_idx in zip(child_node.children, child_idxs, strict=False):
             leaf_start = cur_offset
             leaf_len = leaf_node.segment_len
-            leaf_tokens = tokens_by_sample[sample_idx][root_len + child_node.segment_len:]
-            assert leaf_tokens.shape[0] == leaf_len, \
-                f"leaf token mismatch: {leaf_tokens.shape[0]} != {leaf_len}"
+            leaf_tokens = tokens_by_sample[sample_idx][root_len + child_node.segment_len :]
+            assert leaf_tokens.shape[0] == leaf_len, f"leaf token mismatch: {leaf_tokens.shape[0]} != {leaf_len}"
             flat_parts.append(leaf_tokens)
             leaf_ranges.append((leaf_start, leaf_start + leaf_len))
             leaf_to_sample.append(sample_idx)
@@ -522,8 +527,7 @@ def _build_multilevel_prefix_tree_params(
             cur_offset += leaf_len
 
     flat_tokens = torch.cat(flat_parts)
-    assert flat_tokens.shape[0] == total_tokens, \
-        f"flat token count mismatch: {flat_tokens.shape[0]} != {total_tokens}"
+    assert flat_tokens.shape[0] == total_tokens, f"flat token count mismatch: {flat_tokens.shape[0]} != {total_tokens}"
 
     # Build loss mask
     flat_loss_mask = None
@@ -531,9 +535,9 @@ def _build_multilevel_prefix_tree_params(
         lm_parts = [loss_masks_by_sample[0][:root_len]]
         for child_idxs, child_node in children_info:
             sample0 = child_idxs[0]
-            lm_parts.append(loss_masks_by_sample[sample0][root_len: root_len + child_node.segment_len])
-            for leaf_node, sample_idx in zip(child_node.children, child_idxs):
-                lm_parts.append(loss_masks_by_sample[sample_idx][root_len + child_node.segment_len:])
+            lm_parts.append(loss_masks_by_sample[sample0][root_len : root_len + child_node.segment_len])
+            for leaf_node, sample_idx in zip(child_node.children, child_idxs, strict=False):
+                lm_parts.append(loss_masks_by_sample[sample_idx][root_len + child_node.segment_len :])
         flat_loss_mask = torch.cat(lm_parts)
 
     # Build position ids: root is 0..root_len-1, each turn2 starts at root_len,
@@ -544,7 +548,7 @@ def _build_multilevel_prefix_tree_params(
     for child_idxs, child_node in children_info:
         # turn2 positions: root_len .. root_len + turn2_len - 1
         pid_parts.append(torch.arange(root_len, root_len + child_node.segment_len, device=device))
-        for leaf_node, _sample_idx in zip(child_node.children, child_idxs):
+        for leaf_node, _sample_idx in zip(child_node.children, child_idxs, strict=False):
             # leaf positions: root_len + turn2_len .. root_len + turn2_len + leaf_len - 1
             leaf_start_pos = root_len + child_node.segment_len
             pid_parts.append(torch.arange(leaf_start_pos, leaf_start_pos + leaf_node.segment_len, device=device))
@@ -559,7 +563,7 @@ def _build_multilevel_prefix_tree_params(
         leaf_ranges=leaf_ranges,
         leaf_segments=leaf_ranges,
         leaf_to_sample=leaf_to_sample,
-        sample_to_leaf_range=dict(zip(leaf_to_sample, leaf_ranges)),
+        sample_to_leaf_range=dict(zip(leaf_to_sample, leaf_ranges, strict=False)),
         q_ranges=q_ranges,
         k_ranges=k_ranges,
         mask_types=mask_types,
@@ -617,6 +621,7 @@ def _build_flex_key(params, device):
 
     # leaf_id[t] = which leaf token t belongs to (-1 = prefix)
     import torch as _torch
+
     leaf_id = _torch.full((total,), -1, dtype=_torch.int32)
     for i, (s, e) in enumerate(params.leaf_ranges):
         leaf_id[s:e] = i
@@ -636,9 +641,9 @@ def _build_flex_key(params, device):
 
     # _compile=False: avoid Triton JIT which takes minutes for new shapes.
     # Memory is handled at the call site via torch.utils.checkpoint.
-    block_mask = create_block_mask(prefix_tree_mask, B=None, H=None,
-                                   Q_LEN=total, KV_LEN=total, device=device,
-                                   _compile=False)
+    block_mask = create_block_mask(
+        prefix_tree_mask, B=None, H=None, Q_LEN=total, KV_LEN=total, device=device, _compile=False
+    )
     block_mask._leaf_id = leaf_id  # keep closure alive
     return block_mask
 
@@ -656,7 +661,7 @@ def _build_magi_key(model, params):
     cfg = unwrap_model(model).config
     num_heads_q = cfg.num_attention_heads
     # GQA: num_query_groups may be set; fall back to num_heads_q if not
-    num_heads_kv = getattr(cfg, 'num_query_groups', num_heads_q) or num_heads_q
+    num_heads_kv = getattr(cfg, "num_query_groups", num_heads_q) or num_heads_q
     head_dim = cfg.kv_channels  # hidden_size // num_attention_heads
 
     # Use the CP group so MAGI dispatch operates across CP ranks only.
@@ -667,6 +672,7 @@ def _build_magi_key(model, params):
     # operate on SP-scattered T/TP tokens which is incorrect for CP>1.
     try:
         from megatron.core import parallel_state as mpu
+
         cp_group = mpu.get_context_parallel_group()
     except Exception:
         cp_group = dist.group.WORLD
@@ -682,9 +688,7 @@ def _build_magi_key(model, params):
         head_dim=head_dim,
         pad_size=0,
         cp_group_or_mesh=cp_group,
-        dist_attn_config=DistAttnConfig(
-            dispatch_config=DispatchConfig(uneven_shard=True)
-        ),
+        dist_attn_config=DistAttnConfig(dispatch_config=DispatchConfig(uneven_shard=True)),
     )
     return magi_key
 
@@ -701,19 +705,17 @@ def _build_magi_key_sp_scaled(original_key, model, tp_size: int):
     import torch.distributed as dist
     from magi_attention.api import DistAttnConfig, magi_attn_flex_key
     from magi_attention.common import AttnRanges
-    from magi_attention.common.enum import AttnMaskType
     from magi_attention.meta.solver.dispatch_solver import DispatchConfig
 
     try:
         from megatron.core import parallel_state as mpu
+
         cp_group = mpu.get_context_parallel_group()
     except Exception:
         cp_group = dist.group.WORLD
 
-    q_ranges_sp = [(r.start // tp_size, r.end // tp_size)
-                   for r in original_key.q_ranges]
-    k_ranges_sp = [(r.start // tp_size, r.end // tp_size)
-                   for r in original_key.k_ranges]
+    q_ranges_sp = [(r.start // tp_size, r.end // tp_size) for r in original_key.q_ranges]
+    k_ranges_sp = [(r.start // tp_size, r.end // tp_size) for r in original_key.k_ranges]
     total_q_sp = original_key.total_seqlen_q // tp_size
     total_k_sp = original_key.total_seqlen_k // tp_size
 
@@ -728,7 +730,5 @@ def _build_magi_key_sp_scaled(original_key, model, tp_size: int):
         head_dim=original_key.head_dim,
         pad_size=0,
         cp_group_or_mesh=cp_group,
-        dist_attn_config=DistAttnConfig(
-            dispatch_config=DispatchConfig(uneven_shard=True)
-        ),
+        dist_attn_config=DistAttnConfig(dispatch_config=DispatchConfig(uneven_shard=True)),
     )

--- a/verl/utils/prefix_tree_params.py
+++ b/verl/utils/prefix_tree_params.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import annotations
 
@@ -52,7 +64,7 @@ class PrefixTreeParams:
         if prefix_end < prefix_start:
             raise ValueError("prefix_range must be non-decreasing")
 
-        for leaf_range, leaf_segment in zip(self.leaf_ranges, self.leaf_segments):
+        for leaf_range, leaf_segment in zip(self.leaf_ranges, self.leaf_segments, strict=False):
             leaf_start, leaf_end = leaf_range
             if leaf_end < leaf_start:
                 raise ValueError("leaf ranges must be non-decreasing")
@@ -75,11 +87,11 @@ class PrefixTreeParams:
                     raise ValueError("leaf ranges must start at or after the shared prefix")
             expected_ranges = [self.prefix_range]
             expected_k_ranges = [self.prefix_range]
-            expected_mask_types = ['causal']
+            expected_mask_types = ["causal"]
             for leaf_range in self.leaf_ranges:
                 expected_ranges.extend([leaf_range, leaf_range])
                 expected_k_ranges.extend([self.prefix_range, leaf_range])
-                expected_mask_types.extend(['full', 'causal'])
+                expected_mask_types.extend(["full", "causal"])
             if self.q_ranges != expected_ranges:
                 raise ValueError("q_ranges do not match root-shared PrefixTree layout")
             if self.k_ranges != expected_k_ranges:
@@ -87,15 +99,15 @@ class PrefixTreeParams:
             if self.mask_types != expected_mask_types:
                 raise ValueError("mask_types do not match root-shared PrefixTree layout")
 
-        for sample_idx, leaf_range in zip(self.leaf_to_sample, self.leaf_ranges):
+        for sample_idx, leaf_range in zip(self.leaf_to_sample, self.leaf_ranges, strict=False):
             if self.sample_to_leaf_range[sample_idx] != leaf_range:
                 raise ValueError("sample_to_leaf_range does not match leaf_to_sample ordering")
 
         for name, tensor in {
-            'flat_tokens': self.flat_tokens,
-            'flat_labels': self.flat_labels,
-            'flat_loss_mask': self.flat_loss_mask,
-            'flat_position_ids': self.flat_position_ids,
+            "flat_tokens": self.flat_tokens,
+            "flat_labels": self.flat_labels,
+            "flat_loss_mask": self.flat_loss_mask,
+            "flat_position_ids": self.flat_position_ids,
         }.items():
             if tensor is not None and tensor.numel() != self.total_seqlen_q:
                 raise ValueError(f"{name} must have total_seqlen_q elements")

--- a/verl/utils/prefix_tree_utils.py
+++ b/verl/utils/prefix_tree_utils.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import annotations
 
@@ -12,14 +24,14 @@ from torch import Tensor
 from verl.utils.prefix_tree_params import PrefixTreeParams, RangeSpec
 
 __all__ = [
-    'TreeNode',
-    'build_prefix_tree_dense_mask',
-    'build_prefix_tree_flex_spec',
-    'build_multilevel_flex_spec',
-    'build_prefix_tree_params',
-    'extract_sample_tensor',
-    'extract_sample_tensors',
-    'longest_common_prefix_length',
+    "TreeNode",
+    "build_prefix_tree_dense_mask",
+    "build_prefix_tree_flex_spec",
+    "build_multilevel_flex_spec",
+    "build_prefix_tree_params",
+    "extract_sample_tensor",
+    "extract_sample_tensors",
+    "longest_common_prefix_length",
 ]
 
 
@@ -44,7 +56,7 @@ class TreeNode:
     """
 
     segment_len: int
-    children: list['TreeNode'] = field(default_factory=list)
+    children: list[TreeNode] = field(default_factory=list)
 
     @property
     def is_leaf(self) -> bool:
@@ -61,7 +73,7 @@ def build_prefix_tree_flex_spec(
 
     q_ranges: list[RangeSpec] = [(0, prefix_len)]
     k_ranges: list[RangeSpec] = [(0, prefix_len)]
-    mask_types = ['causal']
+    mask_types = ["causal"]
 
     current = prefix_len
     for branch_len in branch_lengths:
@@ -71,18 +83,18 @@ def build_prefix_tree_flex_spec(
         branch_range = (current, current + branch_len)
         q_ranges.append(branch_range)
         k_ranges.append((0, prefix_len))
-        mask_types.append('full')
+        mask_types.append("full")
 
         q_ranges.append(branch_range)
         k_ranges.append(branch_range)
-        mask_types.append('causal')
+        mask_types.append("causal")
         current += branch_len
 
     return q_ranges, k_ranges, mask_types
 
 
 def build_multilevel_flex_spec(
-    root: 'TreeNode',
+    root: TreeNode,
 ) -> tuple[list[RangeSpec], list[RangeSpec], list[str]]:
     """Encode a multi-level prefix tree as MAGI flex rectangles.
 
@@ -139,7 +151,7 @@ def build_multilevel_flex_spec(
         # Self-attention: causal over this node's own tokens.
         q_ranges.append(node_range)
         k_ranges.append(node_range)
-        mask_types.append('causal')
+        mask_types.append("causal")
 
         if node.is_leaf:
             return
@@ -151,7 +163,7 @@ def build_multilevel_flex_spec(
             desc_range: RangeSpec = (desc._flat_start, desc._flat_end)  # type: ignore[attr-defined]
             q_ranges.append(desc_range)
             k_ranges.append(node_range)
-            mask_types.append('full')
+            mask_types.append("full")
 
         for child in node.children:
             _emit_node(child)
@@ -176,7 +188,7 @@ def build_prefix_tree_dense_mask(
         raise ValueError("total_tokens must be non-negative")
 
     mask = torch.zeros(total_tokens, total_tokens, dtype=torch.bool, device=device)
-    for (q_start, q_end), (k_start, k_end), mask_type in zip(q_ranges, k_ranges, mask_types):
+    for (q_start, q_end), (k_start, k_end), mask_type in zip(q_ranges, k_ranges, mask_types, strict=False):
         if q_start < 0 or k_start < 0 or q_end < q_start or k_end < k_start:
             raise ValueError("range specs must be non-decreasing and non-negative")
         if q_end > total_tokens or k_end > total_tokens:
@@ -184,10 +196,10 @@ def build_prefix_tree_dense_mask(
         if q_end == q_start or k_end == k_start:
             continue
 
-        if mask_type == 'full':
+        if mask_type == "full":
             mask[q_start:q_end, k_start:k_end] = True
             continue
-        if mask_type != 'causal':
+        if mask_type != "causal":
             raise ValueError(f"Unsupported mask type: {mask_type}")
 
         q_pos = torch.arange(q_start, q_end, device=mask.device).unsqueeze(1)
@@ -199,7 +211,7 @@ def build_prefix_tree_dense_mask(
 
 def longest_common_prefix_length(sequences: Sequence[Tensor]) -> int:
     """Return the longest common token prefix across 1D tensors."""
-    reference = _validate_sequence_field('sequences', sequences)
+    reference = _validate_sequence_field("sequences", sequences)
     prefix_len = reference.numel()
 
     for sequence in sequences[1:]:
@@ -231,7 +243,7 @@ def build_prefix_tree_params(
     samples. Autoregressive next-token labels often diverge at the prefix/leaf boundary, so callers
     should omit labels unless they have already accounted for that ambiguity.
     """
-    tokens_reference = _validate_sequence_field('tokens_by_sample', tokens_by_sample)
+    tokens_reference = _validate_sequence_field("tokens_by_sample", tokens_by_sample)
     normalized_sample_indices = _normalize_sample_indices(len(tokens_by_sample), sample_indices)
 
     if prefix_len is None:
@@ -241,23 +253,21 @@ def build_prefix_tree_params(
             raise ValueError("prefix_len must be non-negative")
         if prefix_len > min(sequence.numel() for sequence in tokens_by_sample):
             raise ValueError("prefix_len cannot exceed the shortest sequence")
-        _validate_shared_prefix('tokens_by_sample', tokens_by_sample, prefix_len)
+        _validate_shared_prefix("tokens_by_sample", tokens_by_sample, prefix_len)
 
     branch_lengths = [sequence.numel() - prefix_len for sequence in tokens_by_sample]
     prefix_range = (0, prefix_len)
     leaf_ranges = _build_leaf_ranges(prefix_len, branch_lengths)
     q_ranges, k_ranges, mask_types = build_prefix_tree_flex_spec(prefix_len, branch_lengths)
 
-    flat_tokens = _flatten_root_shared_field('tokens_by_sample', tokens_by_sample, prefix_len)
-    flat_labels = _flatten_optional_field('labels_by_sample', labels_by_sample, tokens_by_sample, prefix_len)
-    flat_loss_mask = _flatten_optional_field(
-        'loss_masks_by_sample', loss_masks_by_sample, tokens_by_sample, prefix_len
-    )
+    flat_tokens = _flatten_root_shared_field("tokens_by_sample", tokens_by_sample, prefix_len)
+    flat_labels = _flatten_optional_field("labels_by_sample", labels_by_sample, tokens_by_sample, prefix_len)
+    flat_loss_mask = _flatten_optional_field("loss_masks_by_sample", loss_masks_by_sample, tokens_by_sample, prefix_len)
     if position_ids_by_sample is None:
         flat_position_ids = _build_default_position_ids(prefix_len, branch_lengths, tokens_reference.device)
     else:
         flat_position_ids = _flatten_optional_field(
-            'position_ids_by_sample', position_ids_by_sample, tokens_by_sample, prefix_len
+            "position_ids_by_sample", position_ids_by_sample, tokens_by_sample, prefix_len
         )
 
     return PrefixTreeParams(
@@ -266,7 +276,7 @@ def build_prefix_tree_params(
         leaf_ranges=leaf_ranges,
         leaf_segments=list(leaf_ranges),
         leaf_to_sample=list(normalized_sample_indices),
-        sample_to_leaf_range=dict(zip(normalized_sample_indices, leaf_ranges)),
+        sample_to_leaf_range=dict(zip(normalized_sample_indices, leaf_ranges, strict=False)),
         q_ranges=q_ranges,
         k_ranges=k_ranges,
         mask_types=mask_types,
@@ -372,11 +382,9 @@ def _validate_auxiliary_field(
     _validate_sequence_field(name, field_by_sample)
     if len(field_by_sample) != len(tokens_by_sample):
         raise ValueError(f"{name} must have the same length as tokens_by_sample")
-    for index, (field_tensor, token_tensor) in enumerate(zip(field_by_sample, tokens_by_sample)):
+    for index, (field_tensor, token_tensor) in enumerate(zip(field_by_sample, tokens_by_sample, strict=False)):
         if field_tensor.numel() != token_tensor.numel():
-            raise ValueError(
-                f"{name}[{index}] must have the same number of elements as tokens_by_sample[{index}]"
-            )
+            raise ValueError(f"{name}[{index}] must have the same number of elements as tokens_by_sample[{index}]")
 
 
 def _validate_sequence_field(name: str, sequences: Sequence[Tensor]) -> Tensor:


### PR DESCRIPTION
Resolves four classes of issues blocking pre-commit on this branch:

1. Device-API usage (check_device_api_usage):
   - Replace torch.cuda.* with verl/utils/device.py's get_torch_device() across model_forward.py (14 occurrences) and prefix_tree_merge.py (4 occurrences).
   - Required by verl rule that device handles go through the unified API so NPU/CUDA stay portable.

2. License headers (check_license):
   - prefix_tree_params.py and prefix_tree_utils.py had a single-line "Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES" header which doesn't match any of the recognised license blocks.
   - magi_patch.py had no header at all.
   - All three now carry the standard Bytedance Apache 2.0 header.

3. Ruff lint:
   - F841: drop unused local `node_start_in_sample` in prefix_tree_magi.py
   - B905: zip-without-explicit-strict (auto-fixed by ruff)
   - UP037: quoted-annotation (auto-fixed by ruff)
   - E501: split an over-long log line in model_forward.py

4. Ruff format:
   - Auto-formatted yumingxuan-added files: model_forward.py, prefix_tree_merge.py, prefix_tree_magi.py, prefix_tree_params.py, prefix_tree_utils.py, magi_patch.py, ray_trainer.py, sft_trainer.py, sft_trainer_ray.py, multiturn_sft_dataset.py, test_prefix_tree_magi.py.
   - No semantic change; whitespace / quote style / import order only.

After this commit `pre-commit run --all-files` is clean on the branch.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
