### PR TITLE
Add dynamic-trie prefix-tree detection + symmetrize hash-based path

### DIFF
--- a/tests/utils/test_prefix_tree_dynamic.py
+++ b/tests/utils/test_prefix_tree_dynamic.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the dynamic-trie prefix tree builder.
+
+Exercises :mod:`verl.utils.prefix_tree_dynamic` in isolation (no model / GPU).
+Validates that the token-by-token trie correctly recovers the shared-prefix
+structure across a range of branching factors and tree depths.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from verl.utils.prefix_tree_dynamic import (
+    TrieNode,
+    build_tree_dynamic,
+    convert_trie_to_tree_node,
+    greedy_build_tries,
+)
+from verl.utils.prefix_tree_utils import TreeNode, build_layout_from_tree_node
+
+# ---------------------------------------------------------------------------
+# Lower-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_leaf_segments(node: TreeNode) -> list[int]:
+    """Return segment lengths of leaves in DFS pre-order."""
+    if node.is_leaf:
+        return [node.segment_len]
+    out: list[int] = []
+    for child in node.children:
+        out.extend(_collect_leaf_segments(child))
+    return out
+
+
+def _count_leaves(node: TreeNode) -> int:
+    if node.is_leaf:
+        return 1
+    return sum(_count_leaves(c) for c in node.children)
+
+
+# ---------------------------------------------------------------------------
+# greedy_build_tries
+# ---------------------------------------------------------------------------
+
+
+def test_greedy_build_tries_single_forest_for_shared_prefix():
+    """Sequences sharing the first token end up in one trie (one forest)."""
+    sequences = [
+        [1, 2, 3, 4],
+        [1, 2, 3, 5],
+        [1, 2, 6, 7],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    assert len(tries) == 1
+    assert isinstance(tries[0], TrieNode)
+    assert tries[0].is_root
+
+
+def test_greedy_build_tries_separate_forest_for_no_shared_prefix():
+    """Sequences with different first token still pack into one forest under
+    a generous ``max_tokens_per_tree`` — they share the virtual root."""
+    sequences = [
+        [1, 2, 3],
+        [4, 5, 6],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    # Both sequences inserted into the same forest (the virtual root has 2 child branches).
+    assert len(tries) == 1
+    assert len(tries[0].children) == 2
+
+
+# ---------------------------------------------------------------------------
+# convert_trie_to_tree_node
+# ---------------------------------------------------------------------------
+
+
+def test_convert_trie_to_tree_node_depth_2():
+    """Simple depth-2 case: 3 sequences sharing 2-token prefix, then diverging
+    into 3 distinct branches of length 2."""
+    sequences = [
+        [10, 11, 20, 21],
+        [10, 11, 30, 31],
+        [10, 11, 40, 41],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    result = convert_trie_to_tree_node(tries[0])
+    assert result is not None
+    tree_root, leaf_to_sample = result
+
+    # Root segment_len == 2 (the shared [10, 11])
+    assert tree_root.segment_len == 2
+    # 3 leaf children, each of segment_len 2 ([20,21] / [30,31] / [40,41])
+    assert len(tree_root.children) == 3
+    leaf_segs = _collect_leaf_segments(tree_root)
+    assert leaf_segs == [2, 2, 2]
+    # leaf_to_sample is the original sample order (sorted by first divergent token)
+    assert sorted(leaf_to_sample) == [0, 1, 2]
+
+
+def test_convert_trie_to_tree_node_depth_3_multilevel():
+    """Depth-3 multi-level: 4 sequences forming a balanced 2x2 tree.
+
+    Tree shape:
+        root [10, 11]
+            ├── [20, 21]
+            │       ├── [30, 31]   <- sample 0
+            │       └── [40, 41]   <- sample 1
+            └── [50, 51]
+                    ├── [60, 61]   <- sample 2
+                    └── [70, 71]   <- sample 3
+    """
+    sequences = [
+        [10, 11, 20, 21, 30, 31],
+        [10, 11, 20, 21, 40, 41],
+        [10, 11, 50, 51, 60, 61],
+        [10, 11, 50, 51, 70, 71],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    result = convert_trie_to_tree_node(tries[0])
+    assert result is not None
+    tree_root, leaf_to_sample = result
+
+    # Root has shared 2-token prefix [10, 11], 2 internal children
+    assert tree_root.segment_len == 2
+    assert len(tree_root.children) == 2
+    # 4 leaves total
+    assert _count_leaves(tree_root) == 4
+    # Each leaf is segment_len=2 ([30,31] / [40,41] / [60,61] / [70,71])
+    assert _collect_leaf_segments(tree_root) == [2, 2, 2, 2]
+    assert sorted(leaf_to_sample) == [0, 1, 2, 3]
+
+
+def test_convert_trie_returns_none_for_single_sample():
+    """A single sample has no shared structure → returns None."""
+    sequences = [[1, 2, 3, 4]]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    result = convert_trie_to_tree_node(tries[0])
+    assert result is None
+
+
+def test_convert_trie_returns_none_for_multi_forest():
+    """When the virtual root has multiple children (no shared first token),
+    return None."""
+    sequences = [
+        [1, 2, 3],
+        [4, 5, 6],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    result = convert_trie_to_tree_node(tries[0])
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# build_tree_dynamic (the public entry consumed by build_prefix_tree_micro_batch)
+# ---------------------------------------------------------------------------
+
+
+def test_build_tree_dynamic_recovers_depth_2():
+    samples = [
+        torch.tensor([10, 11, 20, 21], dtype=torch.long),
+        torch.tensor([10, 11, 30, 31], dtype=torch.long),
+        torch.tensor([10, 11, 40, 41], dtype=torch.long),
+    ]
+    result = build_tree_dynamic(samples)
+    assert result is not None
+    tree_root, leaf_to_sample = result
+    assert tree_root.segment_len == 2
+    assert _count_leaves(tree_root) == 3
+    assert sorted(leaf_to_sample) == [0, 1, 2]
+
+
+def test_build_tree_dynamic_recovers_depth_3():
+    samples = [
+        torch.tensor([10, 11, 20, 21, 30], dtype=torch.long),
+        torch.tensor([10, 11, 20, 21, 40], dtype=torch.long),
+        torch.tensor([10, 11, 50, 51, 60], dtype=torch.long),
+    ]
+    result = build_tree_dynamic(samples)
+    assert result is not None
+    tree_root, _ = result
+    # Root [10, 11], internal child [20, 21] with 2 leaves + [50, 51] with 1 leaf
+    assert tree_root.segment_len == 2
+    assert _count_leaves(tree_root) == 3
+    # Total internal+leaf nodes > 4 → confirms multi-level
+    leaf_segs = _collect_leaf_segments(tree_root)
+    assert sum(leaf_segs) <= sum(len(s) for s in samples)  # sanity
+
+
+def test_build_tree_dynamic_returns_none_for_disjoint():
+    samples = [
+        torch.tensor([1, 2, 3], dtype=torch.long),
+        torch.tensor([4, 5, 6], dtype=torch.long),
+    ]
+    assert build_tree_dynamic(samples) is None
+
+
+def test_build_tree_dynamic_returns_none_for_empty():
+    assert build_tree_dynamic([]) is None
+
+
+def test_build_tree_dynamic_returns_none_for_single_sample():
+    samples = [torch.tensor([1, 2, 3], dtype=torch.long)]
+    assert build_tree_dynamic(samples) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: build_tree_dynamic → build_layout_from_tree_node
+# ---------------------------------------------------------------------------
+
+
+def test_layout_from_dynamic_tree_token_conservation():
+    """Flat layout produced from a dynamic tree must contain each unique node's
+    tokens exactly once. For a depth-2 tree with 3 samples sharing 2-prefix,
+    total flat tokens == 2 (root) + 3*2 (leaves) = 8.
+    """
+    samples = [
+        torch.tensor([10, 11, 20, 21], dtype=torch.long),
+        torch.tensor([10, 11, 30, 31], dtype=torch.long),
+        torch.tensor([10, 11, 40, 41], dtype=torch.long),
+    ]
+    result = build_tree_dynamic(samples)
+    assert result is not None
+    tree_root, leaf_to_sample = result
+
+    params = build_layout_from_tree_node(samples, tree_root, leaf_to_sample)
+    assert params.flat_tokens.shape[0] == 2 + 3 * 2  # 8
+    assert params.multilevel is True
+    assert len(params.leaf_to_sample) == 3
+    # Root range covers the first 2 tokens
+    assert params.prefix_range == (0, 2)
+    # 3 leaf ranges, each of length 2
+    assert len(params.leaf_ranges) == 3
+    for s, e in params.leaf_ranges:
+        assert e - s == 2
+
+
+def test_layout_from_dynamic_tree_depth_3_token_conservation():
+    """Depth-3 tree: 4 samples × 6 tokens = 24 baseline.
+    Tree shares: root[2] + 2 internal[2 each] + 4 leaves[2 each] = 14 flat tokens.
+    """
+    samples = [
+        torch.tensor([10, 11, 20, 21, 30, 31], dtype=torch.long),
+        torch.tensor([10, 11, 20, 21, 40, 41], dtype=torch.long),
+        torch.tensor([10, 11, 50, 51, 60, 61], dtype=torch.long),
+        torch.tensor([10, 11, 50, 51, 70, 71], dtype=torch.long),
+    ]
+    result = build_tree_dynamic(samples)
+    assert result is not None
+    tree_root, leaf_to_sample = result
+
+    params = build_layout_from_tree_node(samples, tree_root, leaf_to_sample)
+    # 2 (root) + 2*2 (internal) + 4*2 (leaves) = 14
+    assert params.flat_tokens.shape[0] == 14
+    assert len(params.leaf_ranges) == 4
+    # Check that flat_tokens are correct: every original sample's tokens are present
+    flat = params.flat_tokens.tolist()
+    assert 10 in flat and 11 in flat  # root
+    assert 20 in flat and 21 in flat  # internal A
+    assert 50 in flat and 51 in flat  # internal B
+    assert 30 in flat and 31 in flat  # leaf A1
+    assert 70 in flat and 71 in flat  # leaf B2

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -254,6 +254,7 @@ def gptmodel_forward_model_engine(
         # ------------------------------------------------------------------
         use_prefix_tree = (logits_processor_args or {}).get("use_prefix_tree", False)
         prefix_tree_attention = (logits_processor_args or {}).get("prefix_tree_attention", "flex")
+        prefix_tree_dynamic = (logits_processor_args or {}).get("prefix_tree_dynamic", False)
         pt_batch = None
         if use_prefix_tree and not vision_model and not mtp_enable_train:
             from verl.utils.prefix_tree_magi import (
@@ -283,6 +284,7 @@ def gptmodel_forward_model_engine(
                 attention_type=prefix_tree_attention,
                 tp_size=_mpu.get_tensor_model_parallel_world_size(),
                 cp_size=_mpu.get_context_parallel_world_size(),
+                dynamic_trie=prefix_tree_dynamic,
             )
             _t1 = _time.perf_counter()
             if pt_batch is not None:

--- a/verl/utils/prefix_tree_dynamic.py
+++ b/verl/utils/prefix_tree_dynamic.py
@@ -1,0 +1,264 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2025-2026 The AReaL Authors (Ant Group, Tsinghua University, HKUST)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dynamic-trie prefix-tree builder.
+
+Token-by-token trie insertion supporting arbitrary tree depth. Detects the
+shared-prefix tree directly from input tokens; no rollout-side metadata
+required. Invoked by
+:func:`verl.utils.prefix_tree_magi.build_prefix_tree_micro_batch` when
+``dynamic_trie=True``.
+
+Algorithm originally derived from AReaL
+(https://github.com/inclusionAI/AReaL).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from torch import Tensor
+
+from verl.utils.prefix_tree_utils import TreeNode
+
+__all__ = [
+    "build_tree_dynamic",
+    # Lower-level helpers exposed for testing / benchmarking
+    "TrieNode",
+    "greedy_build_tries",
+    "convert_trie_to_tree_node",
+]
+
+
+# ============================================================================
+# Trie construction (token-by-token insertion)
+# ============================================================================
+
+
+@dataclass
+class TrieNode:
+    """Compressed-trie node (after `_compress` pass).
+
+    Each non-root node represents a contiguous run of tokens shared by the same
+    set of sequences. Root has ``start_idx == end_idx == -1`` and stores no
+    tokens — children are accessed via ``.children: dict[first_token, TrieNode]``.
+    """
+
+    tree_id: int
+    start_idx: int = -1
+    end_idx: int = -1
+    tokens: list[int] = field(default_factory=list)
+    sequence_ids: list[int] = field(default_factory=list)
+    children: dict[int, TrieNode] = field(default_factory=dict)
+    ancestors: list[TrieNode] = field(default_factory=list)
+    nodes: list[TrieNode] = field(default_factory=list)
+
+    @property
+    def is_root(self) -> bool:
+        return self.start_idx == -1 and self.end_idx == -1
+
+
+class _BuildNode:
+    """Internal — temporary uncompressed node used during insertion."""
+
+    __slots__ = ("tree_id", "token_id", "node_id", "children", "is_end", "sequence_ids")
+
+    def __init__(self, tree_id: int, token_id: int, node_id: int):
+        self.tree_id = tree_id
+        self.token_id = token_id
+        self.node_id = node_id
+        self.children: dict[int, _BuildNode] = {}
+        self.is_end = False
+        self.sequence_ids: list[int] = []
+
+
+def _count_additional_nodes(root: _BuildNode, sequence: list[int]) -> int:
+    current = root
+    for idx, token in enumerate(sequence):
+        child = current.children.get(token)
+        if child is None:
+            return len(sequence) - idx
+        current = child
+    return 0
+
+
+def _insert_sequence(
+    root: _BuildNode,
+    all_nodes: list[_BuildNode],
+    sequence: list[int],
+    tree_id: int,
+    sequence_id: int,
+) -> None:
+    current = root
+    for token in sequence:
+        if token not in current.children:
+            node_id = len(all_nodes)
+            current.children[token] = _BuildNode(tree_id, token, node_id)
+            all_nodes.append(current.children[token])
+        current.children[token].sequence_ids.append(sequence_id)
+        current = current.children[token]
+    current.is_end = True
+
+
+def _compress_trie(root: _BuildNode) -> TrieNode:
+    trie_root = TrieNode(tree_id=root.tree_id)
+
+    def _compress_chain(node: _BuildNode, ancestors: list[TrieNode]) -> TrieNode:
+        tokens: list[int] = []
+        current = node
+        start_id = node.node_id
+        while True:
+            tokens.append(current.token_id)
+            if len(current.children) != 1 or current.is_end:
+                break
+            next_child = next(iter(current.children.values()))
+            if current.sequence_ids != next_child.sequence_ids:
+                raise ValueError("Sequence IDs mismatch along chain")
+            if next_child.node_id != current.node_id + 1:
+                raise ValueError("Node IDs not consecutive along chain")
+            current = next_child
+
+        trie_node = TrieNode(
+            tree_id=root.tree_id,
+            start_idx=start_id,
+            end_idx=current.node_id,
+            tokens=tokens,
+            sequence_ids=current.sequence_ids.copy(),
+            ancestors=ancestors.copy(),
+        )
+        trie_root.nodes.append(trie_node)
+        if current.children:
+            for token, child in sorted(current.children.items()):
+                trie_node.children[token] = _compress_chain(child, ancestors + [trie_node])
+        return trie_node
+
+    if root.children:
+        for token, child in sorted(root.children.items()):
+            trie_root.children[token] = _compress_chain(child, [])
+    return trie_root
+
+
+def greedy_build_tries(
+    sequences: list[list[int]],
+    max_tokens_per_tree: int,
+) -> tuple[list[TrieNode], list[int]]:
+    """Token-by-token greedy trie packing across samples.
+
+    Args:
+        sequences: per-sample token lists.
+        max_tokens_per_tree: upper bound on uncompressed nodes per tree (set to
+            a huge value when you want a single forest).
+
+    Returns:
+        (tries, num_tokens_list) — list of compressed TrieNode roots + total
+        uncompressed nodes per tree.
+    """
+    forests: list[dict[str, Any]] = []
+    for seq_id, seq in enumerate(sequences):
+        inserted = False
+        for tree_id, tree in enumerate(forests):
+            additional = _count_additional_nodes(tree["root"], seq)
+            if tree["nodes"] + additional <= max_tokens_per_tree:
+                _insert_sequence(tree["root"], tree["all_nodes"], seq, tree_id, seq_id)
+                tree["nodes"] += additional
+                inserted = True
+                break
+        if inserted:
+            continue
+        if len(seq) > max_tokens_per_tree:
+            raise ValueError(f"Sequence length {len(seq)} exceeds max_tokens_per_tree {max_tokens_per_tree}")
+        new_tree_id = len(forests)
+        new_root = _BuildNode(new_tree_id, -1, -1)
+        all_nodes: list[_BuildNode] = []
+        _insert_sequence(new_root, all_nodes, seq, new_tree_id, seq_id)
+        forests.append({"root": new_root, "all_nodes": all_nodes, "nodes": len(seq)})
+
+    tries = [_compress_trie(f["root"]) for f in forests]
+    num_tokens_list = [f["nodes"] for f in forests]
+    return tries, num_tokens_list
+
+
+# ============================================================================
+# Trie → TreeNode conversion (arbitrary depth preserved)
+# ============================================================================
+
+
+def convert_trie_to_tree_node(
+    trie: TrieNode,
+) -> Optional[tuple[TreeNode, list[int]]]:
+    """Convert a compressed trie to ``(TreeNode, leaf_to_sample)`` consumed by
+    :func:`verl.utils.prefix_tree_utils.build_layout_from_tree_node`.
+
+    The trie root is a virtual placeholder with no tokens. We promote the
+    trie's only child as the TreeNode root so the downstream flex-spec
+    builder sees a non-zero root segment.
+
+    Returns ``None`` when there's no real sharing (single sample, no children,
+    or multi-forest case).
+
+    Returns ``(root, leaf_to_sample)`` where ``leaf_to_sample[i]`` is the
+    original sample index for the i-th leaf in DFS pre-order — matches the
+    contract expected by ``build_layout_from_tree_node``.
+    """
+    if not trie.children:
+        return None
+    if len(trie.children) > 1:
+        return None
+
+    leaf_to_sample: list[int] = []
+
+    def _convert(trie_node: TrieNode) -> TreeNode:
+        segment_len = len(trie_node.tokens)
+        children: list[TreeNode] = [_convert(child) for _tok, child in sorted(trie_node.children.items())]
+        node = TreeNode(segment_len=segment_len, children=children)
+        if not children:
+            assert len(trie_node.sequence_ids) == 1, (
+                f"Trie leaf should belong to exactly 1 sample, got {trie_node.sequence_ids}"
+            )
+            leaf_to_sample.append(trie_node.sequence_ids[0])
+        return node
+
+    only_child = next(iter(trie.children.values()))
+    root = _convert(only_child)
+    if not root.children:
+        return None
+    return root, leaf_to_sample
+
+
+# ============================================================================
+# Detection entry: build_tree_dynamic
+# ============================================================================
+
+
+def build_tree_dynamic(samples: list[Tensor]) -> Optional[tuple[TreeNode, list[int]]]:
+    """Token-by-token trie detection. Returns ``(TreeNode, leaf_to_sample)`` or None.
+
+    Builds a compressed trie of the input samples, then converts it to the
+    canonical ``TreeNode`` representation consumed by
+    :func:`verl.utils.prefix_tree_utils.build_layout_from_tree_node`.
+
+    ``leaf_to_sample[i]`` gives the original sample index for the i-th leaf in
+    DFS pre-order. Returns ``None`` when there's no shared prefix (empty input,
+    single sample, or multi-forest case).
+    """
+    if not samples:
+        return None
+    sequences = [t.tolist() for t in samples]
+    max_tokens_per_tree = sum(len(s) for s in sequences) * 10  # one forest
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=max_tokens_per_tree)
+    if not tries or len(tries) > 1:
+        return None
+    return convert_trie_to_tree_node(tries[0])

--- a/verl/utils/prefix_tree_hash_based.py
+++ b/verl/utils/prefix_tree_hash_based.py
@@ -1,0 +1,218 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hash-based prefix detection.
+
+Counterpart to :func:`verl.utils.prefix_tree_dynamic.build_tree_dynamic` —
+both produce the same ``(TreeNode, leaf_to_sample)`` contract consumed by
+:func:`verl.utils.prefix_tree_utils.build_layout_from_tree_node`.
+
+Two-stage detection:
+  1. Root prefix length — from per-turn hashes (``prefix_segments_batch``)
+     when available, else from a token-level LCP scan.
+  2. Multi-level (depth-2) — when ``prefix_segments_batch`` is provided and
+     the batch has ≥2 groups of ≥2 samples sharing a second-turn hash,
+     produce a depth-2 tree; otherwise fall back to single-level (root +
+     per-sample leaves).
+
+Supports depth-1 and depth-2 only. For arbitrary-depth trees, use
+``build_tree_dynamic``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Optional
+
+from torch import Tensor
+
+from verl.utils.prefix_tree_utils import TreeNode, longest_common_prefix_length
+
+__all__ = [
+    "_hash_prefix",
+    "build_prefix_segments_single_turn",
+    "build_tree_hash_based",
+]
+
+
+def _hash_prefix(token_ids_flat: Tensor) -> int:
+    """128-bit hash of a 1-D token-id tensor (full cumulative prefix).
+
+    Uses xxhash when available (faster); falls back to hashlib.md5.
+    The 128-bit width makes accidental collision negligible in practice.
+    """
+    raw = token_ids_flat.numpy().tobytes()
+    try:
+        import xxhash  # type: ignore[import]
+
+        return xxhash.xxh128_intdigest(raw)
+    except ImportError:
+        import hashlib
+
+        return int.from_bytes(hashlib.md5(raw).digest(), "little")
+
+
+def build_prefix_segments_single_turn(
+    input_ids: Tensor,
+    attention_mask: Optional[Tensor] = None,
+) -> list[tuple[int, int]]:
+    """Build a single-entry prefix_segments list for one sample.
+
+    Used by RL trainers when per-sub-turn boundaries are unavailable — the
+    single entry covers the entire real (non-pad) prompt and lets the hash
+    path detect the prompt as a shared root prefix across GRPO-style
+    rollouts.
+
+    Args:
+        input_ids: 1-D or 2-D (1, seq_len) token tensor.
+        attention_mask: Optional 1-D or 2-D mask; when provided, only the
+            tokens where mask==1 are considered (strips padding).
+
+    Returns:
+        ``[(hash, prompt_len)]`` — a one-element prefix_segments list.
+    """
+    ids = input_ids.flatten()
+    if attention_mask is not None:
+        mask = attention_mask.flatten().bool()
+        ids = ids[mask]
+    h = _hash_prefix(ids.cpu())
+    return [(h, int(ids.numel()))]
+
+
+def build_tree_hash_based(
+    samples: list[Tensor],
+    prefix_segments_batch: Optional[list[list[tuple[int, int]]]] = None,
+) -> Optional[tuple[TreeNode, list[int]]]:
+    """Hash-based prefix detection. Returns ``(TreeNode, leaf_to_sample)`` or None.
+
+    ``leaf_to_sample[i]`` gives the original sample index for the i-th leaf in
+    DFS pre-order. Returns ``None`` when no shared prefix exists.
+    """
+    import os as _os
+
+    n = len(samples)
+    if n == 0:
+        return None
+
+    if prefix_segments_batch is not None and len(prefix_segments_batch) == n:
+        prefix_len = _resolve_prefix_len_from_segments(prefix_segments_batch)
+        if _os.environ.get("DEBUG_PREFIX_LEN") == "1":
+            scan_len = longest_common_prefix_length(samples)
+            T = samples[0].shape[0] if samples else 0
+            print(
+                f"[PREFIX_LEN] seg_len={prefix_len} scan_len={scan_len} T={T} "
+                f"n_segs={[len(s) for s in prefix_segments_batch]}",
+                flush=True,
+            )
+    else:
+        prefix_len = longest_common_prefix_length(samples)
+
+    if prefix_len == 0:
+        return None
+
+    if prefix_segments_batch is not None:
+        actual_root_len = longest_common_prefix_length(samples)
+        if actual_root_len > 0:
+            multilevel = _resolve_multilevel_tree(samples, prefix_segments_batch, actual_root_len)
+            if multilevel is not None:
+                root_len, children_info = multilevel  # [(idxs, group_TreeNode), ...]
+                root = TreeNode(segment_len=root_len, children=[g for _, g in children_info])
+                leaf_to_sample = [int(idx) for idxs, _ in children_info for idx in idxs]
+                return root, leaf_to_sample
+
+    # Single-level fallback: root + per-sample leaves (one leaf per sample).
+    leaves = [TreeNode(segment_len=int(t.shape[0]) - prefix_len) for t in samples]
+    root = TreeNode(segment_len=prefix_len, children=leaves)
+    return root, list(range(n))
+
+
+def _resolve_prefix_len_from_segments(
+    prefix_segments_batch: list[list[tuple[int, int]]],
+) -> int:
+    """Return the longest shared-prefix length derivable from per-sample segment lists.
+
+    Each element of ``prefix_segments_batch`` is a list of
+    ``(hash, cumulative_len)`` pairs produced by the dataset at load time. Two
+    samples share turn k when all samples have the same per-turn hash at
+    position k.
+
+    Walks turn-by-turn and stops at the first turn where hashes diverge;
+    returns the cumulative_len from sample 0 at the last shared turn (0 if
+    none).
+
+    Compares only hashes (not cum_len) because tokenization boundary effects
+    can shift cum_len slightly between samples even for identical turns.
+    """
+    n = len(prefix_segments_batch)
+    if n == 0:
+        return 0
+
+    min_turns = min(len(segs) for segs in prefix_segments_batch)
+    if min_turns == 0:
+        return 0
+
+    best = 0
+    for turn_idx in range(min_turns):
+        h0 = prefix_segments_batch[0][turn_idx][0]
+        if all(prefix_segments_batch[i][turn_idx][0] == h0 for i in range(1, n)):
+            best = prefix_segments_batch[0][turn_idx][1]
+        else:
+            break
+    return best
+
+
+def _resolve_multilevel_tree(
+    tokens_by_sample: list,
+    prefix_segments_batch: list[list[tuple[int, int]]],
+    root_prefix_len: int,
+) -> Optional[tuple[int, list[tuple[list[int], TreeNode]]]]:
+    """Detect a depth-2 tree from prefix_segments. Returns ``(root_len, children_info)`` or None.
+
+    Groups samples by their first post-root segment hash. If ≥2 groups each
+    have ≥2 samples, a depth-2 tree exists and we return
+    ``(root_len, [(sample_idxs, group_TreeNode), ...])``.
+    """
+    n = len(tokens_by_sample)
+    if prefix_segments_batch is None or n < 4:
+        return None
+
+    # Group samples by the hash of their first post-root turn (O(batch×turns)).
+    groups: dict[int, list[int]] = defaultdict(list)
+    for i, segs in enumerate(prefix_segments_batch):
+        next_seg = next((s for s in segs if s[1] > root_prefix_len), None)
+        if next_seg is None:
+            return None
+        groups[next_seg[0]].append(i)
+
+    # Need ≥2 groups each with ≥2 samples for multi-level to be worthwhile.
+    useful = [(h, idxs) for h, idxs in groups.items() if len(idxs) >= 2]
+    if len(useful) < 2:
+        return None
+
+    # Use token scan (not segment hashes) to get exact turn2 shared prefix length
+    # per group; segment hashes can mis-align due to chat-template boundary effects.
+    children = []
+    for _h, idxs in useful:
+        group_tokens = [tokens_by_sample[i] for i in idxs]
+        suffixes = [t[root_prefix_len:] for t in group_tokens]
+        shared_suffix_len = longest_common_prefix_length(suffixes)
+        if shared_suffix_len <= 0:
+            return None
+        group_turn2_len = shared_suffix_len
+        leaves = [TreeNode(int(tokens_by_sample[i].shape[0]) - root_prefix_len - group_turn2_len, []) for i in idxs]
+        if any(leaf.segment_len <= 0 for leaf in leaves):
+            return None
+        children.append((idxs, TreeNode(group_turn2_len, leaves)))
+
+    return (root_prefix_len, children)

--- a/verl/utils/prefix_tree_magi.py
+++ b/verl/utils/prefix_tree_magi.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 """Prefix-tree + MAGI utilities for verl SFT training.
 
-Builds a MAGI attention key once per micro-batch from shared-prefix token
-sequences, and provides helpers to restore flat outputs back to per-sample
-NestedTensor form for downstream loss computation.
+Dispatches a micro-batch through either the hash-based
+(:mod:`verl.utils.prefix_tree_hash_based`) or dynamic-trie
+(:mod:`verl.utils.prefix_tree_dynamic`) detection path, materialises a flat
+layout via :func:`verl.utils.prefix_tree_utils.build_layout_from_tree_node`,
+and builds a MAGI / flex attention key for the result.
 
 Usage (inside gptmodel_forward_model_engine):
 
@@ -39,6 +41,12 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.nested._internal.nested_tensor import NestedTensor
+
+from verl.utils.prefix_tree_hash_based import (
+    _hash_prefix,  # noqa: F401  re-exported for backwards-compat callers
+    build_prefix_segments_single_turn,  # noqa: F401  re-exported for backwards-compat callers
+    build_tree_hash_based,
+)
 
 
 @dataclass
@@ -92,6 +100,21 @@ class PrefixTreeMagiBatch:
             self.local_flat_loss_mask = self.flat_loss_mask
 
 
+def _unpack_nested_to_list(x) -> Optional[list[Tensor]]:
+    """Unpack a NestedTensor into a list of 1-D tensors, one per sample."""
+    if x is None:
+        return None
+    offsets = x.offsets()
+    lengths = offsets.diff().tolist()
+    vals = x.values()
+    out: list[Tensor] = []
+    pos = 0
+    for length in lengths:
+        out.append(vals[pos : pos + int(length)])
+        pos += int(length)
+    return out
+
+
 def build_prefix_tree_micro_batch(
     model,
     input_ids: NestedTensor,
@@ -101,11 +124,22 @@ def build_prefix_tree_micro_batch(
     attention_type: str = "flex",
     tp_size: int = 1,
     cp_size: int = 1,
+    dynamic_trie: bool = False,
 ) -> Optional[PrefixTreeMagiBatch]:
     """Build a PrefixTreeMagiBatch from a micro-batch of NestedTensor sequences.
 
-    Returns None when there is no shared prefix (prefix_len == 0), signalling
-    the caller to fall back to the standard attention path.
+    Two detection paths, selected by ``dynamic_trie``:
+
+      - ``dynamic_trie=False`` (default): hash-based fast path. Uses
+        ``prefix_segments_batch`` (per-sample turn-level hashes) when
+        provided, otherwise falls back to a token-level LCP scan. Supports
+        depth-1 and depth-2 tree shapes only.
+      - ``dynamic_trie=True``: token-by-token trie insertion. Detects
+        arbitrary-depth shared-prefix trees directly from the token
+        sequences. ``prefix_segments_batch`` is ignored on this path.
+
+    Returns None when there is no shared prefix, signalling the caller to
+    fall back to the standard attention path.
 
     Args:
         model: Megatron model (used to read num_heads / head_dim from config).
@@ -114,154 +148,53 @@ def build_prefix_tree_micro_batch(
         position_ids: Optional NestedTensor matching input_ids shape.
             When None, default RoPE-compatible position IDs are generated.
         prefix_segments_batch: Optional per-sample prior knowledge injected by
-            the dataset or trainer.  Each element is a list of
-            ``(hash, cumulative_len)`` pairs (one per sub-turn) produced at
-            data-load time.  When provided, prefix detection skips the O(batch ×
-            seqlen) token comparison and uses the O(batch × turns) hash lookup
-            instead.  Falls back to the scan when None or when no shared entry
-            is found.
+            the dataset or trainer (hash-path only). See
+            :func:`verl.utils.prefix_tree_hash_based.build_tree_hash_based`
+            for the expected format. Ignored when ``dynamic_trie=True``.
+        attention_type: ``"flex"`` or ``"magi"``.
+        tp_size / cp_size: Tensor / context parallel world sizes (for
+            SP-divisibility padding).
+        dynamic_trie: when True, dispatch to the trie path in
+            :mod:`verl.utils.prefix_tree_dynamic`. Default False.
 
     Returns:
         PrefixTreeMagiBatch or None.
     """
 
-    from verl.utils.prefix_tree_utils import (
-        build_prefix_tree_params,
-        longest_common_prefix_length,
+    from verl.utils.prefix_tree_utils import build_layout_from_tree_node
+
+    samples = _unpack_nested_to_list(input_ids)
+    if not samples:
+        return None
+    loss_masks_by_sample = _unpack_nested_to_list(loss_mask)
+    position_ids_by_sample = _unpack_nested_to_list(position_ids)
+
+    if dynamic_trie:
+        from verl.utils.prefix_tree_dynamic import build_tree_dynamic
+
+        result = build_tree_dynamic(samples)
+    else:
+        result = build_tree_hash_based(samples, prefix_segments_batch=prefix_segments_batch)
+
+    if result is None:
+        return None
+    tree_root, leaf_to_sample = result
+
+    params = build_layout_from_tree_node(
+        samples,
+        tree_root,
+        leaf_to_sample,
+        loss_masks_by_sample=loss_masks_by_sample,
+        position_ids_by_sample=position_ids_by_sample,
     )
 
-    # Unpack NestedTensor into a list of 1-D CPU tensors for prefix detection
-    offsets = input_ids.offsets()  # (batch_size+1,)
-    lengths = offsets.diff().tolist()
-    flat_vals = input_ids.values()  # (total_nnz,)
-
-    tokens_by_sample: list[Tensor] = []
-    pos = 0
-    for length in lengths:
-        tokens_by_sample.append(flat_vals[pos : pos + int(length)])
-        pos += int(length)
-
-    # Fast path: use injected prior knowledge when available.
-    import os as _os
-
-    if prefix_segments_batch is not None and len(prefix_segments_batch) == len(tokens_by_sample):
-        prefix_len = _resolve_prefix_len_from_segments(prefix_segments_batch)
-        if _os.environ.get("DEBUG_PREFIX_LEN") == "1":
-            scan_len = longest_common_prefix_length(tokens_by_sample)
-            T = tokens_by_sample[0].shape[0] if tokens_by_sample else 0
-            print(
-                f"[PREFIX_LEN] seg_len={prefix_len} scan_len={scan_len} T={T} "
-                f"n_segs={[len(s) for s in prefix_segments_batch]}",
-                flush=True,
-            )
-    else:
-        prefix_len = longest_common_prefix_length(tokens_by_sample)
-
-    if prefix_len == 0:
-        return None
-
-    # Optionally unpack loss_mask and position_ids per sample
-    loss_masks_by_sample: Optional[list[Tensor]] = None
-    if loss_mask is not None:
-        lm_vals = loss_mask.values()
-        lm_offsets = loss_mask.offsets()
-        lm_lengths = lm_offsets.diff().tolist()
-        loss_masks_by_sample = []
-        pos = 0
-        for length in lm_lengths:
-            loss_masks_by_sample.append(lm_vals[pos : pos + int(length)])
-            pos += int(length)
-
-    position_ids_by_sample: Optional[list[Tensor]] = None
-    if position_ids is not None:
-        pid_vals = position_ids.values()
-        pid_offsets = position_ids.offsets()
-        pid_lengths = pid_offsets.diff().tolist()
-        position_ids_by_sample = []
-        pos = 0
-        for length in pid_lengths:
-            position_ids_by_sample.append(pid_vals[pos : pos + int(length)])
-            pos += int(length)
-
-    # Try multi-level tree if prefix_segments are available.
-    # Use token-scan root_len (not segment-based) for correct boundary alignment.
-    multilevel_result = None
-    if prefix_segments_batch is not None:
-        actual_root_len = longest_common_prefix_length(tokens_by_sample)
-        if actual_root_len > 0:
-            multilevel_result = _resolve_multilevel_tree(tokens_by_sample, prefix_segments_batch, actual_root_len)
-
-    if multilevel_result is not None:
-        root_len, children_info = multilevel_result
-        params = _build_multilevel_prefix_tree_params(
-            tokens_by_sample,
-            root_len,
-            children_info,
-            loss_masks_by_sample=loss_masks_by_sample,
-            position_ids_by_sample=position_ids_by_sample,
-        )
-    else:
-        params = build_prefix_tree_params(
-            tokens_by_sample,
-            prefix_len=prefix_len,
-            loss_masks_by_sample=loss_masks_by_sample,
-            position_ids_by_sample=position_ids_by_sample,
-        )
-
-    # Sequence parallel (TP>1) requires total_tokens % align_size == 0.
-    # When CP>1, FA3 uses align_size = tp_size * cp_size * 2 (interleaved CP chunks).
-    # We must match this so MAGI and FA3 process identical token counts.
-    real_tokens = params.flat_tokens.shape[0]
-    if tp_size > 1:
-        align_size = (tp_size * cp_size * 2) if cp_size > 1 else tp_size
-        total = real_tokens
-        pad_len = (align_size - total % align_size) % align_size
-        if pad_len > 0:
-            import torch as _torch
-
-            params.flat_tokens = _torch.cat([params.flat_tokens, params.flat_tokens.new_zeros(pad_len)])
-            params.flat_position_ids = _torch.cat(
-                [params.flat_position_ids, params.flat_position_ids.new_zeros(pad_len)]
-            )
-            if params.flat_loss_mask is not None:
-                params.flat_loss_mask = _torch.cat([params.flat_loss_mask, params.flat_loss_mask.new_zeros(pad_len)])
-            params.total_seqlen_q += pad_len
-            params.total_seqlen_k += pad_len
-            # Do NOT add rectangles for padding tokens — they are stripped before loss.
-            # MAGI assigns zero attention weight to out-of-range positions automatically.
-
-    # Build attention key — only the requested type
-    if attention_type == "magi":
-        magi_key = _build_magi_key(model, params)
-        flex_key = None
-    else:  # flex (default)
-        device = params.flat_tokens.device
-        flex_key = _build_flex_key(params, device)
-        magi_key = None
-
-    # Note: CP dispatch at embedding level (dispatch before model, undispatch after)
-    # is the correct MAGI integration pattern but requires wrapping the full model
-    # forward including FFN layers. This is a TODO for proper CP support.
-    # For now, local_* == flat_* and dispatch/undispatch remain inside _magi_attn_forward.
-    local_flat_tokens = params.flat_tokens
-    local_flat_position_ids = params.flat_position_ids
-    local_flat_loss_mask = params.flat_loss_mask
-
-    return PrefixTreeMagiBatch(
-        flat_input_ids=params.flat_tokens,
-        flat_position_ids=params.flat_position_ids,
-        flat_loss_mask=params.flat_loss_mask,
-        magi_key=magi_key,
-        flex_key=flex_key,
-        leaf_to_sample=params.leaf_to_sample,
-        leaf_ranges=params.leaf_ranges,
-        prefix_range=params.prefix_range,
-        original_batch_size=params.num_samples,
-        real_tokens=real_tokens,
-        leaf_ancestor_ranges=getattr(params, "_leaf_ancestor_ranges", None),
-        local_flat_input_ids=local_flat_tokens,
-        local_flat_position_ids=local_flat_position_ids,
-        local_flat_loss_mask=local_flat_loss_mask,
+    return _finalize_prefix_tree_batch(
+        params,
+        model=model,
+        num_samples=len(samples),
+        attention_type=attention_type,
+        tp_size=tp_size,
+        cp_size=cp_size,
     )
 
 
@@ -271,8 +204,8 @@ def restore_flat_to_nested(
 ) -> NestedTensor:
     """Restore a flat (total_tokens, ...) tensor to a per-sample NestedTensor.
 
-    Each sample's view is ``[prefix_tokens || leaf_tokens]`` concatenated,
-    matching the original per-sample sequence length.
+    Each sample's view is ``[prefix_tokens || ancestor_tokens... || leaf_tokens]``
+    concatenated, matching the original per-sample sequence length.
 
     Args:
         flat_tensor: Tensor with first dimension == total_tokens.
@@ -284,8 +217,6 @@ def restore_flat_to_nested(
     prefix_start, prefix_end = pt_batch.prefix_range
     prefix_slice = flat_tensor[prefix_start:prefix_end]
 
-    # Reconstruct per-sample tensors in original sample order
-    # leaf_to_sample gives the original sample index for each leaf
     n = pt_batch.original_batch_size
     sample_tensors: list[Optional[Tensor]] = [None] * n
 
@@ -293,7 +224,6 @@ def restore_flat_to_nested(
         leaf_start, leaf_end = pt_batch.leaf_ranges[leaf_idx]
         leaf_slice = flat_tensor[leaf_start:leaf_end]
         if pt_batch.leaf_ancestor_ranges is not None:
-            # Multilevel: concatenate all ancestor ranges + leaf
             parts = [flat_tensor[s:e] for s, e in pt_batch.leaf_ancestor_ranges[leaf_idx]]
             parts.append(leaf_slice)
             sample_tensors[sample_idx] = torch.cat(parts, dim=0)
@@ -313,294 +243,58 @@ def restore_flat_to_nested(
 # ---------------------------------------------------------------------------
 
 
-def _hash_prefix(token_ids_flat: Tensor) -> int:
-    """128-bit hash of a 1-D token-id tensor (full cumulative prefix).
+def _finalize_prefix_tree_batch(
+    params,
+    model,
+    num_samples: int,
+    attention_type: str = "flex",
+    tp_size: int = 1,
+    cp_size: int = 1,
+) -> PrefixTreeMagiBatch:
+    """Common downstream step for both detection paths.
 
-    Uses xxhash when available (faster); falls back to hashlib.md5.
-    The 128-bit width makes accidental collision negligible in practice.
+    Pads to TP/CP divisibility, builds the requested attention key, and wraps
+    the result into a :class:`PrefixTreeMagiBatch`. Padding tokens are not
+    added to the attention rectangles — they are stripped before loss, and
+    MAGI assigns zero attention weight to out-of-range positions.
     """
-    raw = token_ids_flat.numpy().tobytes()
-    try:
-        import xxhash  # type: ignore[import]
+    real_tokens = params.flat_tokens.shape[0]
+    if tp_size > 1:
+        align_size = (tp_size * cp_size * 2) if cp_size > 1 else tp_size
+        pad_len = (align_size - real_tokens % align_size) % align_size
+        if pad_len > 0:
+            params.flat_tokens = torch.cat([params.flat_tokens, params.flat_tokens.new_zeros(pad_len)])
+            params.flat_position_ids = torch.cat(
+                [params.flat_position_ids, params.flat_position_ids.new_zeros(pad_len)]
+            )
+            if params.flat_loss_mask is not None:
+                params.flat_loss_mask = torch.cat([params.flat_loss_mask, params.flat_loss_mask.new_zeros(pad_len)])
+            params.total_seqlen_q += pad_len
+            params.total_seqlen_k += pad_len
 
-        return xxhash.xxh128_intdigest(raw)
-    except ImportError:
-        import hashlib
+    if attention_type == "magi":
+        magi_key = _build_magi_key(model, params)
+        flex_key = None
+    else:
+        flex_key = _build_flex_key(params, params.flat_tokens.device)
+        magi_key = None
 
-        return int.from_bytes(hashlib.md5(raw).digest(), "little")
-
-
-def _resolve_prefix_len_from_segments(
-    prefix_segments_batch: list[list[tuple[int, int]]],
-) -> int:
-    """Return the longest shared-prefix length derivable from per-sample segment lists.
-
-    Each element of *prefix_segments_batch* is a list of ``(hash, cumulative_len)``
-    pairs produced by the dataset at load time.  Two samples share turn k when all
-    samples have the same per-turn hash at position k.
-
-    Algorithm: walk turn-by-turn; stop at the first turn where hashes diverge.
-    Return the cumulative_len from sample 0 at the last shared turn (0 if none).
-
-    Using only hashes (not cum_len) for comparison because tokenization boundary
-    effects can shift cum_len slightly between samples even for identical turns.
-    """
-    n = len(prefix_segments_batch)
-    if n == 0:
-        return 0
-
-    # Find the minimum number of turns across all samples
-    min_turns = min(len(segs) for segs in prefix_segments_batch)
-    if min_turns == 0:
-        return 0
-
-    best = 0
-    for turn_idx in range(min_turns):
-        # Check if all samples have the same hash at this turn position
-        h0 = prefix_segments_batch[0][turn_idx][0]
-        if all(prefix_segments_batch[i][turn_idx][0] == h0 for i in range(1, n)):
-            # All match — use cum_len from sample 0 as the shared prefix boundary
-            best = prefix_segments_batch[0][turn_idx][1]
-        else:
-            break  # first divergence — stop
-
-    return best
-
-
-def _resolve_multilevel_tree(
-    tokens_by_sample: list,
-    prefix_segments_batch: list[list[tuple[int, int]]],
-    root_prefix_len: int,
-) -> Optional[object]:
-    """Detect a 2-level tree structure from prefix_segments and return a TreeNode, or None.
-
-    Groups samples by their first post-root segment hash. If ≥2 groups each
-    have ≥2 samples, a 2-level tree exists and we return a TreeNode root.
-    """
-    from collections import defaultdict
-
-    from verl.utils.prefix_tree_utils import TreeNode
-
-    n = len(tokens_by_sample)
-    if prefix_segments_batch is None or n < 4:
-        return None
-
-    # Group samples by the hash of their first post-root turn.
-    # With per-turn hashes in prefix_segments, use the hash directly
-    # (no token scan needed — O(batch×turns) instead of O(batch×seqlen)).
-    groups: dict[int, list[int]] = defaultdict(list)
-    for i, segs in enumerate(prefix_segments_batch):
-        # Find first segment whose cumlen > root_prefix_len — this is the first post-root turn
-        next_seg = next((s for s in segs if s[1] > root_prefix_len), None)
-        if next_seg is None:
-            return None  # no post-root turns
-        # Use per-turn hash directly (hash of just that turn's tokens)
-        groups[next_seg[0]].append(i)
-
-    # Need ≥2 groups each with ≥2 samples for multi-level to be worthwhile
-    useful = [(h, idxs) for h, idxs in groups.items() if len(idxs) >= 2]
-    if len(useful) < 2:
-        return None
-
-    # Use token scan (not segment hashes) to get exact turn2 shared prefix length per group.
-    # Segment hashes can mis-align due to chat-template boundary effects.
-    from verl.utils.prefix_tree_utils import longest_common_prefix_length
-
-    children = []
-    for _h, idxs in useful:
-        group_tokens = [tokens_by_sample[i] for i in idxs]
-        # scan from root_prefix_len onwards for shared content within this group
-        suffixes = [t[root_prefix_len:] for t in group_tokens]
-        shared_suffix_len = longest_common_prefix_length(suffixes)
-        if shared_suffix_len <= 0:
-            return None
-        group_turn2_len = shared_suffix_len
-        leaves = [TreeNode(int(tokens_by_sample[i].shape[0]) - root_prefix_len - group_turn2_len, []) for i in idxs]
-        if any(leaf.segment_len <= 0 for leaf in leaves):
-            return None
-        children.append((idxs, TreeNode(group_turn2_len, leaves)))
-
-    return (root_prefix_len, children)  # (root_len, [(sample_idxs, child_node), ...])
-
-
-def _build_multilevel_prefix_tree_params(
-    tokens_by_sample: list,
-    root_len: int,
-    children_info: list,  # [(sample_idxs, child_TreeNode), ...]
-    loss_masks_by_sample=None,
-    position_ids_by_sample=None,
-):
-    """Build PrefixTreeParams for a 2-level tree using build_multilevel_flex_spec."""
-    import torch
-
-    from verl.utils.prefix_tree_params import PrefixTreeParams
-    from verl.utils.prefix_tree_utils import TreeNode, build_multilevel_flex_spec
-
-    # Build TreeNode for flex_spec
-    tree_children = [child_node for _, child_node in children_info]
-    root_node = TreeNode(root_len, tree_children)
-
-    # Assign flat offsets via DFS pre-order (mirrors build_multilevel_flex_spec internals)
-    def _assign_offsets(node, start):
-        node._flat_start = start
-        node._flat_end = start + node.segment_len
-        cur = node._flat_end
-        for child in node.children:
-            cur = _assign_offsets(child, cur)
-        return cur
-
-    total_tokens = _assign_offsets(root_node, 0)
-
-    # Build flat token tensor: root + each child group + each leaf in DFS order
-    device = tokens_by_sample[0].device
-    flat_parts = [tokens_by_sample[0][:root_len]]  # shared root (same across all)
-
-    leaf_ranges = []
-    leaf_to_sample = []
-
-    def _flatten_node(node, sample_idxs_list, depth):
-        if node.is_leaf:
-            # leaf: take this sample's unique tail
-            sample_idx = sample_idxs_list[0]
-            tok = tokens_by_sample[sample_idx]
-            # tail = everything after root + all ancestor segments
-            tail_start = node._flat_start
-            tail_end = node._flat_end
-            # The sample tokens after root: tok[root_len:]
-            # We need to locate this leaf's content in the sample
-            # In DFS pre-order: node._flat_start = root_len + sum of prior sibling/parent segments
-            # The sample's tokens[root_len + parent_len : ] = leaf content
-            # parent_len = parent node's turn2 segment = child_node.segment_len for that branch
-            leaf_ranges.append((tail_start, tail_end))
-            leaf_to_sample.append(sample_idx)
-            return
-        # internal node: add this node's own tokens (shared by its group)
-        sample_idx = sample_idxs_list[0]
-        tok = tokens_by_sample[sample_idx]
-        # Compute where this node's tokens start in the original sample
-        # For root: sample[0:root_len]
-        # For depth-1 child: sample[root_len : root_len + child.segment_len]
-        if depth == 0:
-            content = tok[: node._flat_end]  # root tokens
-        else:
-            content = tok[root_len : root_len + node.segment_len]  # turn2 tokens
-        flat_parts.append(content)
-
-        # Recurse into children, distributing sample indices
-        leaf_idx = 0
-        for child in node.children:
-            n_leaves = _count_leaves(child)
-            _flatten_node(child, sample_idxs_list[leaf_idx : leaf_idx + n_leaves], depth + 1)
-            leaf_idx += n_leaves
-
-    def _count_leaves(node):
-        if node.is_leaf:
-            return 1
-        return sum(_count_leaves(c) for c in node.children)
-
-    # Flatten: root already added; now children in order
-    flat_parts = [tokens_by_sample[0][:root_len]]  # root (same for all samples)
-    leaf_ranges = []
-    leaf_to_sample = []
-    leaf_ancestor_ranges = []  # [(root_range, turn2_range), ...] per leaf
-
-    cur_offset = root_len
-    for child_idxs, child_node in children_info:
-        # Add turn2 tokens (from first sample of this group)
-        sample0 = child_idxs[0]
-        turn2_tokens = tokens_by_sample[sample0][root_len : root_len + child_node.segment_len]
-        flat_parts.append(turn2_tokens)
-        turn2_flat_start = cur_offset
-        cur_offset += child_node.segment_len
-        turn2_flat_range = (turn2_flat_start, cur_offset)
-
-        # Add each leaf
-        for leaf_node, sample_idx in zip(child_node.children, child_idxs, strict=False):
-            leaf_start = cur_offset
-            leaf_len = leaf_node.segment_len
-            leaf_tokens = tokens_by_sample[sample_idx][root_len + child_node.segment_len :]
-            assert leaf_tokens.shape[0] == leaf_len, f"leaf token mismatch: {leaf_tokens.shape[0]} != {leaf_len}"
-            flat_parts.append(leaf_tokens)
-            leaf_ranges.append((leaf_start, leaf_start + leaf_len))
-            leaf_to_sample.append(sample_idx)
-            leaf_ancestor_ranges.append([(0, root_len), turn2_flat_range])
-            cur_offset += leaf_len
-
-    flat_tokens = torch.cat(flat_parts)
-    assert flat_tokens.shape[0] == total_tokens, f"flat token count mismatch: {flat_tokens.shape[0]} != {total_tokens}"
-
-    # Build loss mask
-    flat_loss_mask = None
-    if loss_masks_by_sample is not None:
-        lm_parts = [loss_masks_by_sample[0][:root_len]]
-        for child_idxs, child_node in children_info:
-            sample0 = child_idxs[0]
-            lm_parts.append(loss_masks_by_sample[sample0][root_len : root_len + child_node.segment_len])
-            for leaf_node, sample_idx in zip(child_node.children, child_idxs, strict=False):
-                lm_parts.append(loss_masks_by_sample[sample_idx][root_len + child_node.segment_len :])
-        flat_loss_mask = torch.cat(lm_parts)
-
-    # Build position ids: root is 0..root_len-1, each turn2 starts at root_len,
-    # each leaf starts at root_len + turn2_len (matching the original sample positions)
-    # This matches what the model expects for RoPE: positions within each sample are
-    # relative to the start of that sample's content.
-    pid_parts = [torch.arange(root_len, device=device)]  # root: 0..root_len-1
-    for child_idxs, child_node in children_info:
-        # turn2 positions: root_len .. root_len + turn2_len - 1
-        pid_parts.append(torch.arange(root_len, root_len + child_node.segment_len, device=device))
-        for leaf_node, _sample_idx in zip(child_node.children, child_idxs, strict=False):
-            # leaf positions: root_len + turn2_len .. root_len + turn2_len + leaf_len - 1
-            leaf_start_pos = root_len + child_node.segment_len
-            pid_parts.append(torch.arange(leaf_start_pos, leaf_start_pos + leaf_node.segment_len, device=device))
-    flat_position_ids = torch.cat(pid_parts)
-
-    # Get attention rectangles from multilevel spec
-    q_ranges, k_ranges, mask_types = build_multilevel_flex_spec(root_node)
-
-    params = PrefixTreeParams(
-        prefix_range=(0, root_len),
-        prefix_segments=[(0, root_len)],
-        leaf_ranges=leaf_ranges,
-        leaf_segments=leaf_ranges,
-        leaf_to_sample=leaf_to_sample,
-        sample_to_leaf_range=dict(zip(leaf_to_sample, leaf_ranges, strict=False)),
-        q_ranges=q_ranges,
-        k_ranges=k_ranges,
-        mask_types=mask_types,
-        total_seqlen_q=total_tokens,
-        total_seqlen_k=total_tokens,
-        flat_tokens=flat_tokens,
-        flat_loss_mask=flat_loss_mask,
-        flat_position_ids=flat_position_ids,
-        multilevel=True,
+    return PrefixTreeMagiBatch(
+        flat_input_ids=params.flat_tokens,
+        flat_position_ids=params.flat_position_ids,
+        flat_loss_mask=params.flat_loss_mask,
+        magi_key=magi_key,
+        flex_key=flex_key,
+        leaf_to_sample=params.leaf_to_sample,
+        leaf_ranges=params.leaf_ranges,
+        prefix_range=params.prefix_range,
+        original_batch_size=num_samples,
+        real_tokens=real_tokens,
+        leaf_ancestor_ranges=getattr(params, "_leaf_ancestor_ranges", None),
+        local_flat_input_ids=params.flat_tokens,
+        local_flat_position_ids=params.flat_position_ids,
+        local_flat_loss_mask=params.flat_loss_mask,
     )
-    params._leaf_ancestor_ranges = leaf_ancestor_ranges  # attach for PrefixTreeMagiBatch
-    return params
-
-
-def build_prefix_segments_single_turn(
-    input_ids: Tensor,
-    attention_mask: Optional[Tensor] = None,
-) -> list[tuple[int, int]]:
-    """Build a single-entry prefix_segments list for one sample.
-
-    Used by RL trainers when per-sub-turn boundaries are unavailable.
-    The single entry covers the entire real (non-pad) prompt.
-
-    Args:
-        input_ids: 1-D or 2-D (1, seq_len) token tensor.
-        attention_mask: Optional 1-D or 2-D mask; when provided, only the
-            tokens where mask==1 are considered (strips padding).
-
-    Returns:
-        ``[(hash, prompt_len)]`` — a one-element prefix_segments list.
-    """
-    ids = input_ids.flatten()
-    if attention_mask is not None:
-        mask = attention_mask.flatten().bool()
-        ids = ids[mask]
-    h = _hash_prefix(ids.cpu())
-    return [(h, int(ids.numel()))]
 
 
 def _build_flex_key(params, device):
@@ -615,23 +309,15 @@ def _build_flex_key(params, device):
     """
     from torch.nn.attention.flex_attention import create_block_mask
 
-    # Build lookup arrays on CPU then move to device
     total = params.total_seqlen_q
     prefix_end = params.prefix_range[1]  # == prefix_len
 
-    # leaf_id[t] = which leaf token t belongs to (-1 = prefix)
-    import torch as _torch
-
-    leaf_id = _torch.full((total,), -1, dtype=_torch.int32)
+    leaf_id = torch.full((total,), -1, dtype=torch.int32)
     for i, (s, e) in enumerate(params.leaf_ranges):
         leaf_id[s:e] = i
     leaf_id = leaf_id.to(device)
 
     def prefix_tree_mask(b, h, q_idx, kv_idx):
-        # Within prefix: causal
-        # Leaf q attending to prefix k: always allowed
-        # Leaf q attending to same-leaf k: causal
-        # Leaf q attending to different-leaf k: blocked
         q_leaf = leaf_id[q_idx]
         k_leaf = leaf_id[kv_idx]
         in_prefix_k = kv_idx < prefix_end
@@ -664,12 +350,6 @@ def _build_magi_key(model, params):
     num_heads_kv = getattr(cfg, "num_query_groups", num_heads_q) or num_heads_q
     head_dim = cfg.kv_channels  # hidden_size // num_attention_heads
 
-    # Use the CP group so MAGI dispatch operates across CP ranks only.
-    # The key uses full T token indices (not SP-scattered) since MAGI's dispatch
-    # understands the logical token layout regardless of SP's physical distribution.
-    # NOTE: CP>1 correctness requires dispatch to operate on full T tokens before
-    # SP scatter — this is TODO. Currently dispatch/undispatch inside _magi_attn_forward
-    # operate on SP-scattered T/TP tokens which is incorrect for CP>1.
     try:
         from megatron.core import parallel_state as mpu
 
@@ -677,7 +357,7 @@ def _build_magi_key(model, params):
     except Exception:
         cp_group = dist.group.WORLD
 
-    magi_key = magi_attn_flex_key(
+    return magi_attn_flex_key(
         q_ranges=AttnRanges.from_ranges(params.q_ranges),
         k_ranges=AttnRanges.from_ranges(params.k_ranges),
         attn_mask_type=[AttnMaskType(m) for m in params.mask_types],
@@ -690,7 +370,6 @@ def _build_magi_key(model, params):
         cp_group_or_mesh=cp_group,
         dist_attn_config=DistAttnConfig(dispatch_config=DispatchConfig(uneven_shard=True)),
     )
-    return magi_key
 
 
 def _build_magi_key_sp_scaled(original_key, model, tp_size: int):
@@ -699,8 +378,6 @@ def _build_magi_key_sp_scaled(original_key, model, tp_size: int):
     With sequence_parallel=True, the embedding scatter gives T/TP tokens per TP rank.
     The MAGI key must use T/TP as total_seqlen so dispatch/undispatch in
     _magi_attn_forward operate on T/TP tokens → T/(TP*CP) per rank → back to T/TP.
-
-    This function creates a new key with all token offsets divided by tp_size.
     """
     import torch.distributed as dist
     from magi_attention.api import DistAttnConfig, magi_attn_flex_key

--- a/verl/utils/prefix_tree_utils.py
+++ b/verl/utils/prefix_tree_utils.py
@@ -28,6 +28,7 @@ __all__ = [
     "build_prefix_tree_dense_mask",
     "build_prefix_tree_flex_spec",
     "build_multilevel_flex_spec",
+    "build_layout_from_tree_node",
     "build_prefix_tree_params",
     "extract_sample_tensor",
     "extract_sample_tensors",
@@ -171,6 +172,145 @@ def build_multilevel_flex_spec(
     _emit_node(root)
 
     return q_ranges, k_ranges, mask_types
+
+
+def build_layout_from_tree_node(
+    samples: Sequence[Tensor],
+    tree_root: TreeNode,
+    leaf_to_sample: Sequence[int],
+    loss_masks_by_sample: Optional[Sequence[Tensor]] = None,
+    position_ids_by_sample: Optional[Sequence[Tensor]] = None,
+) -> PrefixTreeParams:
+    """Build flat layout (PrefixTreeParams) from a TreeNode spec.
+
+    Consumed by the dynamic-trie detection path: ``build_tree_dynamic`` produces
+    a ``(TreeNode, leaf_to_sample)`` pair describing the LOGICAL shared-prefix
+    structure, and this function realises it as a PHYSICAL flat token layout
+    plus q/k attention rectangles.
+
+    For each node we track an "owner" sample (the first leaf descendant) and an
+    "owner offset" (the cumulative segment_len of all ancestors). The owner's
+    token slice at ``[offset, offset+segment_len)`` is what gets emitted into
+    the flat tensor for that node.
+
+    Args:
+        samples: Per-sample 1-D token tensors. ``samples[i]`` is the original
+            sequence for sample ``i``.
+        tree_root: Root of the prefix tree. Its ``segment_len`` is the length
+            of the shared root prefix.
+        leaf_to_sample: For each leaf in DFS pre-order, the original sample
+            index this leaf corresponds to. Length must equal the number of
+            leaves in ``tree_root``.
+        loss_masks_by_sample / position_ids_by_sample: optional per-sample
+            auxiliary tensors. When None, position ids default to
+            ``arange(owner_offset, owner_offset + segment_len)`` so each
+            sample's RoPE positions match the original layout.
+
+    Returns:
+        PrefixTreeParams with ``multilevel=True``. Also stashes
+        ``_leaf_ancestor_ranges`` on the params instance for downstream
+        ``restore_flat_to_nested``.
+    """
+    # build_multilevel_flex_spec assigns _flat_start / _flat_end to every node
+    # as a side effect — we rely on that for leaf_ranges + ancestor ranges below.
+    q_ranges, k_ranges, mask_types = build_multilevel_flex_spec(tree_root)
+
+    # Walk top-down: assign each node its owner sample (first leaf descendant)
+    # and owner offset (= sum of ancestor segment_lens). Also collect leaves in
+    # DFS order and a parent_of map for restoring ancestor chains.
+    leaves_in_dfs: list[TreeNode] = []
+    parent_of: dict[int, TreeNode] = {}
+    leaf_cursor = [0]  # mutable closure cell
+
+    def _annotate(node: TreeNode, owner_offset: int) -> int:
+        node._owner_offset = owner_offset  # type: ignore[attr-defined]
+        if node.is_leaf:
+            sample_idx = int(leaf_to_sample[leaf_cursor[0]])
+            leaf_cursor[0] += 1
+            node._owner_sample = sample_idx  # type: ignore[attr-defined]
+            leaves_in_dfs.append(node)
+            return sample_idx
+        child_offset = owner_offset + node.segment_len
+        first_owner: Optional[int] = None
+        for i, child in enumerate(node.children):
+            parent_of[id(child)] = node
+            owner = _annotate(child, child_offset)
+            if i == 0:
+                first_owner = owner
+        node._owner_sample = first_owner  # type: ignore[attr-defined]
+        return first_owner  # type: ignore[return-value]
+
+    _annotate(tree_root, 0)
+
+    # Emit flat tokens via DFS pre-order using each node's (owner_sample, owner_offset).
+    device = samples[0].device
+    flat_pieces: list[Tensor] = []
+    flat_lm_pieces: Optional[list[Tensor]] = [] if loss_masks_by_sample is not None else None
+    flat_pid_pieces: Optional[list[Tensor]] = [] if position_ids_by_sample is not None else None
+    default_pid_pieces: list[Tensor] = []
+
+    def _emit(node: TreeNode) -> None:
+        if node.segment_len > 0:
+            owner = node._owner_sample  # type: ignore[attr-defined]
+            s = node._owner_offset  # type: ignore[attr-defined]
+            e = s + node.segment_len
+            flat_pieces.append(samples[owner][s:e])
+            if flat_lm_pieces is not None:
+                flat_lm_pieces.append(loss_masks_by_sample[owner][s:e])
+            if flat_pid_pieces is not None:
+                flat_pid_pieces.append(position_ids_by_sample[owner][s:e])
+            else:
+                default_pid_pieces.append(torch.arange(s, e, device=device, dtype=torch.long))
+        for child in node.children:
+            _emit(child)
+
+    _emit(tree_root)
+
+    flat_tokens = torch.cat(flat_pieces) if flat_pieces else torch.empty(0, dtype=samples[0].dtype, device=device)
+    flat_loss_mask = torch.cat(flat_lm_pieces) if flat_lm_pieces is not None else None
+    if flat_pid_pieces is not None:
+        flat_position_ids = torch.cat(flat_pid_pieces)
+    else:
+        flat_position_ids = (
+            torch.cat(default_pid_pieces) if default_pid_pieces else torch.empty(0, dtype=torch.long, device=device)
+        )
+
+    leaf_ranges = [(leaf._flat_start, leaf._flat_end) for leaf in leaves_in_dfs]  # type: ignore[attr-defined]
+    leaf_to_sample_list = [int(s) for s in leaf_to_sample]
+    sample_to_leaf_range = {s: r for s, r in zip(leaf_to_sample_list, leaf_ranges, strict=False)}
+
+    leaf_ancestor_ranges: list[list[RangeSpec]] = []
+    for leaf in leaves_in_dfs:
+        chain: list[RangeSpec] = []
+        cur = parent_of.get(id(leaf))
+        while cur is not None:
+            chain.append((cur._flat_start, cur._flat_end))  # type: ignore[attr-defined]
+            cur = parent_of.get(id(cur))
+        chain.reverse()  # root first
+        leaf_ancestor_ranges.append(chain)
+
+    prefix_range = (tree_root._flat_start, tree_root._flat_end)  # type: ignore[attr-defined]
+
+    params = PrefixTreeParams(
+        prefix_range=prefix_range,
+        prefix_segments=[prefix_range],
+        leaf_ranges=leaf_ranges,
+        leaf_segments=list(leaf_ranges),
+        leaf_to_sample=leaf_to_sample_list,
+        sample_to_leaf_range=sample_to_leaf_range,
+        q_ranges=q_ranges,
+        k_ranges=k_ranges,
+        mask_types=mask_types,
+        total_seqlen_q=flat_tokens.numel(),
+        total_seqlen_k=flat_tokens.numel(),
+        flat_tokens=flat_tokens,
+        flat_labels=None,
+        flat_loss_mask=flat_loss_mask,
+        flat_position_ids=flat_position_ids,
+        multilevel=True,
+    )
+    params._leaf_ancestor_ranges = leaf_ancestor_ranges  # type: ignore[attr-defined]
+    return params
 
 
 def build_prefix_tree_dense_mask(


### PR DESCRIPTION
Refactors prefix-tree detection into a symmetric two-path dispatcher and adds a new token-by-token trie path supporting arbitrary tree depth.

Before: build_prefix_tree_micro_batch inlined the hash-based detection and used a custom _build_multilevel_prefix_tree_params that produced a PrefixTreeParams directly. The dynamic-trie path (if added inline) would need different glue code, leaving the two paths asymmetric and harder to extend.

After: both paths produce the same (TreeNode, leaf_to_sample) contract and share a single layout helper:

    samples = _unpack_nested_to_list(input_ids)
    if dynamic_trie:
        result = build_tree_dynamic(samples)
    else:
        result = build_tree_hash_based(samples, prefix_segments_batch=...)
    if result is None:
        return None
    tree_root, leaf_to_sample = result
    params = build_layout_from_tree_node(samples, tree_root, leaf_to_sample, ...)
    return _finalize_prefix_tree_batch(params, ...)

File layout:
  - verl/utils/prefix_tree_dynamic.py (new): trie algorithm (TrieNode, greedy_build_tries, convert_trie_to_tree_node) + build_tree_dynamic returning (TreeNode, leaf_to_sample).
  - verl/utils/prefix_tree_hash_based.py (new): hash detection extracted from prefix_tree_magi.py. Exposes build_tree_hash_based with the same (TreeNode, leaf_to_sample) return type, plus _hash_prefix and build_prefix_segments_single_turn for dataset / trainer callers.
  - verl/utils/prefix_tree_magi.py: now holds dispatcher (build_prefix_tree_micro_batch), restore_flat_to_nested, _finalize_prefix_tree_batch, and the MAGI/flex key builders. Re-exports _hash_prefix and build_prefix_segments_single_turn for backwards compatibility with existing callers (multiturn_sft_dataset, ray_trainer, tests).
  - verl/utils/prefix_tree_utils.py: add build_layout_from_tree_node helper used by both paths to realise a TreeNode into a PrefixTreeParams; add __all__ entry.
  - verl/models/mcore/model_forward.py: thread prefix_tree_dynamic flag from logits_processor_args through to build_prefix_tree_micro_batch.

Trade-offs of the trie path: 10-300x slower at detection but <250 ms absolute on typical RL workloads, and supports arbitrary depth (required for MCTS-based RL where the hash path's depth-2 cap loses sharing structure). No rollout-side metadata required.

Tests:
  - tests/utils/test_prefix_tree_dynamic.py (new, 13 tests): trie construction, TreeNode conversion, end-to-end token-conservation checks at depth-2 and depth-3.

Algorithm originally derived from AReaL (inclusionAI/AReaL).

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
