### PR TITLE
Add FSDP backend for dynamic prefix-tree + Magi attention

### DIFF
--- a/prefix_script/fsdp/compare_training_metrics.py
+++ b/prefix_script/fsdp/compare_training_metrics.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Compare per-step training metrics between two verl training runs.
+
+Parses verl's console-logger format (one line per step):
+
+    step:N - key1:val1 - key2:val2 - ...
+
+For each requested metric, computes per-step abs/rel diff vs baseline, then
+applies thresholds (per-step max + overall Pearson correlation). Reports
+PASS/FAIL per metric and overall. Also dumps a JSON of all numbers for
+downstream inspection.
+
+Usage
+-----
+    python compare_training_metrics.py \\
+        --baseline_log /tmp/dense.log \\
+        --treatment_log /tmp/tree.log \\
+        --label "tree non-CP vs dense" \\
+        --output /tmp/compare_noncp.json
+
+Default metric set + thresholds match what we use in the convergence test
+(see research/2026-06-01-tree-training-test-plan.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+# Ray colours its per-worker prefix with ANSI escapes (e.g. \x1b[36m(...)\x1b[0m).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+# Ray prefixes step lines with "(TaskRunner pid=NNN) " when logged through Ray.
+_RAY_PREFIX_RE = re.compile(r"^\([\w]+\s+pid=\d+\)\s+")
+# step:NN - key:value - key:value - ...
+_STEP_LINE_RE = re.compile(r"^step:(\d+)\s+-\s+(.*)$")
+# verl wraps metric values in np.<type>(...) (e.g. np.float64(0.18), np.int32(2)).
+_NP_WRAP_RE = re.compile(r"^np\.\w+\((.*)\)$")
+
+
+def _parse_value(s: str) -> Optional[float]:
+    s = s.strip().rstrip("-").strip()
+    m = _NP_WRAP_RE.match(s)
+    if m:
+        s = m.group(1).strip()
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def parse_log(path: str) -> dict[int, dict[str, float]]:
+    """Parse verl console-logger lines. Returns {step: {metric_name: value}}."""
+    out: dict[int, dict[str, float]] = {}
+    with open(path) as f:
+        for line in f:
+            # Strip ANSI colour codes Ray injects around its (worker pid=NNN) prefix.
+            line = _ANSI_RE.sub("", line).strip()
+            # Strip optional "(TaskRunner pid=NNN) " Ray prefix
+            ray_m = _RAY_PREFIX_RE.match(line)
+            if ray_m:
+                line = line[ray_m.end() :]
+            m = _STEP_LINE_RE.match(line)
+            if not m:
+                continue
+            step = int(m.group(1))
+            rest = m.group(2)
+            step_metrics: dict[str, float] = {}
+            for part in rest.split(" - "):
+                if ":" not in part:
+                    continue
+                k, _, v = part.partition(":")
+                k = k.strip()
+                val = _parse_value(v)
+                if val is None:
+                    continue
+                step_metrics[k] = val
+            if step_metrics:
+                out[step] = step_metrics
+    return out
+
+
+@dataclass
+class MetricSpec:
+    name: str
+    max_per_step_abs_diff: Optional[float] = None  # |diff| < threshold each step
+    max_per_step_rel_diff: Optional[float] = None  # |diff| / max(|b|, eps) < threshold each step
+    min_correlation: Optional[float] = None  # Pearson corr across all aligned steps
+    allow_missing: bool = False  # don't fail when metric absent from logs
+
+
+DEFAULT_METRICS = [
+    # Loss should be very close (FFA bf16 non-determinism is the main noise floor)
+    MetricSpec("actor/pg_loss", max_per_step_rel_diff=0.10, min_correlation=0.95),
+    # Reward is in [0, 1] for GSM8K — abs diff is interpretable; rollout sampling
+    # adds variance so correlation threshold is more forgiving
+    MetricSpec("critic/score/mean", max_per_step_abs_diff=0.05, min_correlation=0.85, allow_missing=True),
+    MetricSpec("reward/mean", max_per_step_abs_diff=0.05, min_correlation=0.85, allow_missing=True),
+    # KL between actor and ref should match very tightly across the two runs
+    MetricSpec("actor/kl_loss", max_per_step_abs_diff=1e-3, allow_missing=True),
+    # Grad norm has more bf16 noise — looser threshold
+    MetricSpec("actor/grad_norm", max_per_step_rel_diff=0.20, min_correlation=0.85, allow_missing=True),
+]
+
+
+def _pearson(xs: list[float], ys: list[float]) -> Optional[float]:
+    n = len(xs)
+    if n < 2:
+        return None
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True))
+    dx2 = sum((x - mx) ** 2 for x in xs)
+    dy2 = sum((y - my) ** 2 for y in ys)
+    denom = (dx2 * dy2) ** 0.5
+    if denom == 0:
+        return None
+    return num / denom
+
+
+@dataclass
+class MetricResult:
+    name: str
+    n_steps: int
+    max_abs_diff: float
+    max_rel_diff: float
+    correlation: Optional[float]
+    has_nan: bool
+    passed: bool
+    reason: str = ""
+
+
+def _is_nan_or_inf(x: float) -> bool:
+    return x != x or x in (float("inf"), float("-inf"))
+
+
+def compare_metric(
+    spec: MetricSpec,
+    base: dict[int, dict[str, float]],
+    treat: dict[int, dict[str, float]],
+) -> Optional[MetricResult]:
+    """Returns None when the metric isn't found in either log and allow_missing=True."""
+    shared_steps = sorted(set(base.keys()) & set(treat.keys()))
+    if not shared_steps:
+        return (
+            None if spec.allow_missing else MetricResult(spec.name, 0, 0.0, 0.0, None, False, False, "no shared steps")
+        )
+
+    pairs: list[tuple[int, float, float]] = []
+    for step in shared_steps:
+        b = base[step].get(spec.name)
+        t = treat[step].get(spec.name)
+        if b is None or t is None:
+            continue
+        pairs.append((step, b, t))
+
+    if not pairs:
+        return (
+            None
+            if spec.allow_missing
+            else MetricResult(spec.name, 0, 0.0, 0.0, None, False, False, "metric not present in logs")
+        )
+
+    bs = [p[1] for p in pairs]
+    ts = [p[2] for p in pairs]
+    has_nan = any(_is_nan_or_inf(b) or _is_nan_or_inf(t) for b, t in zip(bs, ts, strict=True))
+    abs_diffs = [abs(t - b) for b, t in zip(bs, ts, strict=True)]
+    rel_diffs = [abs(t - b) / max(abs(b), 1e-9) for b, t in zip(bs, ts, strict=True)]
+    max_abs = max(abs_diffs)
+    max_rel = max(rel_diffs)
+    corr = _pearson(bs, ts)
+
+    reasons = []
+    if has_nan:
+        reasons.append("NaN/Inf in metric values")
+    if spec.max_per_step_abs_diff is not None and max_abs > spec.max_per_step_abs_diff:
+        reasons.append(f"max_abs_diff {max_abs:.4g} > {spec.max_per_step_abs_diff:.4g}")
+    if spec.max_per_step_rel_diff is not None and max_rel > spec.max_per_step_rel_diff:
+        reasons.append(f"max_rel_diff {max_rel:.4g} > {spec.max_per_step_rel_diff:.4g}")
+    if spec.min_correlation is not None and (corr is None or corr < spec.min_correlation):
+        reasons.append(f"correlation {corr} < {spec.min_correlation}")
+
+    passed = not reasons
+    return MetricResult(
+        name=spec.name,
+        n_steps=len(pairs),
+        max_abs_diff=max_abs,
+        max_rel_diff=max_rel,
+        correlation=corr,
+        has_nan=has_nan,
+        passed=passed,
+        reason="; ".join(reasons),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline_log", required=True, help="Path to baseline (e.g. dense) training log")
+    parser.add_argument("--treatment_log", required=True, help="Path to treatment (e.g. tree) training log")
+    parser.add_argument("--label", default="treatment vs baseline", help="Human-readable label for the report")
+    parser.add_argument("--output", default=None, help="Optional JSON path for machine-readable results")
+    parser.add_argument(
+        "--metrics",
+        default=None,
+        help="Comma-separated metric names to override the default set (uses default thresholds)",
+    )
+    args = parser.parse_args()
+
+    base = parse_log(args.baseline_log)
+    treat = parse_log(args.treatment_log)
+    print(f"[COMPARE] {args.label}")
+    print(f"[COMPARE]   baseline:  {args.baseline_log}  ({len(base)} steps)")
+    print(f"[COMPARE]   treatment: {args.treatment_log} ({len(treat)} steps)")
+
+    if not base or not treat:
+        print("[COMPARE] FAIL: one or both logs have zero parsed steps")
+        return 1
+
+    if args.metrics:
+        wanted = set(args.metrics.split(","))
+        specs = [m for m in DEFAULT_METRICS if m.name in wanted]
+        if not specs:
+            specs = [MetricSpec(name=n) for n in wanted]  # no thresholds, just report numbers
+    else:
+        specs = DEFAULT_METRICS
+
+    results: list[MetricResult] = []
+    print()
+    print(f"{'Metric':<30} {'n':>5} {'max_abs':>10} {'max_rel':>10} {'corr':>8} {'NaN':>5}  status")
+    print("-" * 90)
+    for spec in specs:
+        r = compare_metric(spec, base, treat)
+        if r is None:
+            print(f"{spec.name:<30} {'-':>5} {'-':>10} {'-':>10} {'-':>8} {'-':>5}  SKIP (not in log)")
+            continue
+        results.append(r)
+        status = "PASS" if r.passed else "FAIL"
+        corr_str = f"{r.correlation:.4f}" if r.correlation is not None else "n/a"
+        print(
+            f"{r.name:<30} {r.n_steps:>5} {r.max_abs_diff:>10.4g} {r.max_rel_diff:>10.4g} "
+            f"{corr_str:>8} {str(r.has_nan):>5}  {status}" + (f"  ({r.reason})" if r.reason else "")
+        )
+
+    overall_pass = all(r.passed for r in results) and bool(results)
+    print()
+    if overall_pass:
+        print(f"[COMPARE] {args.label}: ALL METRICS PASS")
+    else:
+        failed = [r.name for r in results if not r.passed]
+        print(f"[COMPARE] {args.label}: FAIL — {len(failed)} metric(s) failed: {', '.join(failed)}")
+
+    if args.output:
+        payload = {
+            "label": args.label,
+            "baseline_log": args.baseline_log,
+            "treatment_log": args.treatment_log,
+            "baseline_steps": len(base),
+            "treatment_steps": len(treat),
+            "results": [asdict(r) for r in results],
+            "overall_pass": overall_pass,
+        }
+        with open(args.output, "w") as f:
+            json.dump(payload, f, indent=2)
+        print(f"[COMPARE] JSON written to {args.output}")
+
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prefix_script/fsdp/inspect_convergence.py
+++ b/prefix_script/fsdp/inspect_convergence.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Per-step side-by-side inspection of two training runs.
+
+Prints a column-aligned table with baseline / treatment / diff for the key
+metrics (pg_loss, reward, kl, grad_norm) so you can see at which step the
+two runs start to diverge.
+
+Usage:
+    python prefix_script/fsdp/inspect_convergence.py \\
+        --baseline_log /tmp/.../R1_dense.log \\
+        --treatment_log /tmp/.../R2_tree_noncp.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Reuse the parser
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from compare_training_metrics import parse_log  # noqa: E402
+
+METRICS = [
+    "actor/pg_loss",
+    "critic/score/mean",
+    "actor/kl_loss",
+    "actor/grad_norm",
+    "actor/entropy",
+    "actor/loss",
+    "actor/ppo_kl",
+    "response_length/mean",
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline_log", required=True)
+    parser.add_argument("--treatment_log", required=True)
+    parser.add_argument(
+        "--metrics",
+        default=None,
+        help="Comma-separated metric names to inspect (defaults to a curated set)",
+    )
+    args = parser.parse_args()
+
+    base = parse_log(args.baseline_log)
+    treat = parse_log(args.treatment_log)
+    if not base or not treat:
+        print(f"[INSPECT] one or both logs have zero parsed steps (base={len(base)}, treat={len(treat)})")
+        return 1
+
+    metric_list = args.metrics.split(",") if args.metrics else METRICS
+
+    print(f"[INSPECT] baseline:  {args.baseline_log}  ({len(base)} steps)")
+    print(f"[INSPECT] treatment: {args.treatment_log} ({len(treat)} steps)")
+    print()
+
+    shared = sorted(set(base.keys()) & set(treat.keys()))
+    for metric in metric_list:
+        any_step_has_it = any(metric in base[s] or metric in treat[s] for s in shared)
+        if not any_step_has_it:
+            continue
+
+        print(f"=== {metric} ===")
+        print(f"{'step':<6} {'baseline':>14} {'treatment':>14} {'abs_diff':>14} {'rel_diff':>10}")
+        print("-" * 66)
+        for step in shared:
+            b_val = base[step].get(metric)
+            t_val = treat[step].get(metric)
+            if b_val is None and t_val is None:
+                continue
+            if b_val is None or t_val is None:
+                only = "treatment" if b_val is None else "baseline"
+                print(
+                    f"{step:<6} {'-' if b_val is None else f'{b_val:14.6g}'}"
+                    f" {'-' if t_val is None else f'{t_val:14.6g}'}"
+                    f" {'(only ' + only + ')':>14} {'-':>10}"
+                )
+                continue
+            abs_diff = t_val - b_val
+            rel_denom = max(abs(b_val), 1e-9)
+            rel_diff = abs(abs_diff) / rel_denom
+            # Flag large diffs for eyeballing
+            flag = ""
+            if abs(abs_diff) > 0.05 and rel_diff > 0.1:
+                flag = "  <-- DIVERGE"
+            print(f"{step:<6} {b_val:>14.6g} {t_val:>14.6g} {abs_diff:>14.6g} {rel_diff:>10.4f}{flag}")
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prefix_script/fsdp/profile_tree_memory.py
+++ b/prefix_script/fsdp/profile_tree_memory.py
@@ -1,0 +1,455 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Profile peak GPU memory of one tree forward+backward vs one dense forward+backward.
+
+Records a torch.cuda memory snapshot for each path. Upload the resulting
+pickles to https://pytorch.org/memory_viz to see the per-tensor timeline
+and identify which allocations cause the tree path to peak higher.
+
+Output files:
+  /tmp/profile_dense_memory.pickle
+  /tmp/profile_tree_memory.pickle
+
+Usage:
+    USE_FSDP=1 torchrun --standalone --nproc_per_node=1 \\
+        prefix_script/fsdp/profile_tree_memory.py
+
+Env knobs (defaults match the convergence test workload):
+    MODEL_PATH    HF model dir (default ~/models/Qwen/Qwen2.5-3B-Instruct)
+    N             rollouts/prompt (default 8)
+    P             prompt length (default 110, matches GSM8K mean)
+    R             response length (default 290, matches GSM8K mean)
+    USE_FSDP      1 to wrap in FSDP2 (default 1)
+    ENABLE_GC     1 to enable HF gradient checkpointing (default 1, matches
+                  verl training defaults). Set 0 to disable for comparison.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+N = int(os.environ.get("N", "8"))
+P = int(os.environ.get("P", "110"))
+R = int(os.environ.get("R", "290"))
+USE_FSDP = os.environ.get("USE_FSDP", "1") == "1"
+ENABLE_GC = os.environ.get("ENABLE_GC", "1") == "1"
+
+
+def _init_dist():
+    if not dist.is_initialized():
+        if "RANK" not in os.environ:
+            raise RuntimeError("Run via torchrun")
+        torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
+        dist.init_process_group(backend="nccl")
+
+
+def _build_fsdp_qwen(model_path):
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.fsdp import MixedPrecisionPolicy
+    from transformers import Qwen2ForCausalLM
+
+    from verl.utils.fsdp_utils import apply_fsdp2, fsdp2_load_full_state_dict
+
+    model = Qwen2ForCausalLM.from_pretrained(model_path, dtype=torch.float32).cuda()
+    world = dist.get_world_size()
+    mesh = init_device_mesh("cuda", mesh_shape=(world,), mesh_dim_names=("fsdp",))
+    mp = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16,
+        reduce_dtype=torch.float32,
+        cast_forward_inputs=True,
+    )
+    full_state = model.state_dict()
+    apply_fsdp2(
+        model,
+        {"mesh": mesh, "mp_policy": mp, "offload_policy": None, "reshard_after_forward": True},
+        config={},
+    )
+    fsdp2_load_full_state_dict(model, full_state, mesh, None)
+    return model
+
+
+def _load_model(model_path, cp_group):
+    from transformers import Qwen2ForCausalLM
+
+    from verl.models.transformers.monkey_patch import apply_magi_prefix_tree_backend_fsdp
+
+    apply_magi_prefix_tree_backend_fsdp()
+
+    if USE_FSDP:
+        model = _build_fsdp_qwen(model_path)
+    else:
+        model = Qwen2ForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16).cuda()
+    model.train()
+    model.config._attn_implementation = "Magi_Attention"
+    model.config.attention_dropout = 0.0
+
+    # verl training enables HF gradient checkpointing by default. Mirror it here
+    # so the profile peaks line up with the production training observation.
+    if ENABLE_GC:
+        # FSDP2 + HF gradient_checkpointing needs use_reentrant=False
+        model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+        print("[PROFILE] gradient checkpointing: ENABLED (use_reentrant=False)")
+    else:
+        print("[PROFILE] gradient checkpointing: DISABLED")
+
+    for _, mod in model.named_modules():
+        cls = mod.__class__.__name__.lower()
+        if cls.endswith(("attention", "self_attn", "selfattention")):
+            mod.cp_group = cp_group
+    return model
+
+
+def _build_batch(model, response_len: int = R):
+    """1 prompt × N rollouts, prompt length P, response length response_len."""
+    torch.manual_seed(42)
+    vocab = model.config.vocab_size
+    prompt = torch.randint(0, vocab, (P,), device="cuda")
+    samples = []
+    for i in range(N):
+        torch.manual_seed(100 + i)
+        response = torch.randint(0, vocab, (response_len,), device="cuda")
+        samples.append(torch.cat([prompt, response]))
+    nested = torch.nested.nested_tensor(samples, layout=torch.jagged)
+    return samples, nested
+
+
+def _tree_forward(model, nested, cp_group):
+    from verl.models.transformers.monkey_patch import set_magi_attention_key_fsdp
+    from verl.utils.prefix_tree_magi import build_prefix_tree_micro_batch, restore_flat_to_nested
+
+    pt_batch = build_prefix_tree_micro_batch(model, nested, attention_type="magi", cp_size=1, dynamic_trie=True)
+    set_magi_attention_key_fsdp(model, pt_batch.magi_key)
+    flat_in = pt_batch.local_flat_input_ids.unsqueeze(0)
+    flat_pos = pt_batch.local_flat_position_ids.unsqueeze(0)
+    out = model(input_ids=flat_in, attention_mask=None, position_ids=flat_pos, use_cache=False)
+    flat_logits = out.logits[0][: pt_batch.real_tokens]
+    nested_logits = restore_flat_to_nested(flat_logits, pt_batch)
+    return [nested_logits[i] for i in range(pt_batch.original_batch_size)]
+
+
+def _dense_forward_per_sample(model, samples):
+    """Per-sample sdpa forward (8 separate forwards, 8 retained graphs).
+
+    Kept for reference; NOT what verl uses in training. Memory dominated by
+    8× retained activations. Caller must set
+    ``model.config._attn_implementation = "sdpa"`` before calling and keep
+    it set through loss.backward().
+    """
+    return [model(input_ids=s.unsqueeze(0), attention_mask=None, use_cache=False).logits[0] for s in samples]
+
+
+def _dense_forward_packed(model, samples):
+    """Packed FA2 forward — matches verl's rmpad path (production dense baseline).
+
+    Concatenate all samples into one flat (1, total_tokens) input, with
+    position_ids that restart at each sample boundary. HF's flash-attention
+    backend infers cu_seqlens from the position_ids resets and applies a
+    per-sample causal mask without materialising a full (T, T) attention
+    matrix — same effective semantics as varlen FA2.
+
+    Caller must set ``model.config._attn_implementation = "flash_attention_2"``
+    BEFORE this call AND keep it set through loss.backward() — otherwise
+    gradient checkpointing recompute uses a different attention impl than
+    the original forward and crashes with a saved-tensor-count mismatch.
+    """
+    flat_input = torch.cat(samples).unsqueeze(0)  # (1, total_tokens)
+    pos_pieces = [torch.arange(s.shape[0], device="cuda", dtype=torch.long) for s in samples]
+    flat_pos = torch.cat(pos_pieces).unsqueeze(0)  # (1, total_tokens), resets per sample
+
+    out = model(
+        input_ids=flat_input,
+        attention_mask=None,
+        position_ids=flat_pos,
+        use_cache=False,
+    )
+
+    # Restore per-sample logits (so loss computation matches tree path's output shape)
+    logits = out.logits[0]  # (total_tokens, vocab)
+    per_sample = []
+    offset = 0
+    for s in samples:
+        per_sample.append(logits[offset : offset + s.shape[0]])
+        offset += s.shape[0]
+    return per_sample
+
+
+def _loss(per_sample, samples):
+    losses = []
+    for logits, s in zip(per_sample, samples, strict=False):
+        f = logits.float()
+        labels = s[1:]
+        logp = torch.log_softmax(f[:-1], dim=-1).gather(1, labels.unsqueeze(1)).squeeze(1)
+        losses.append(-logp.mean())
+    return torch.stack(losses).mean()
+
+
+def _magi_lru_size(cp_group) -> int:
+    """Return current size of Magi's per-cp_group runtime LRU. 0 if Magi
+    internals not importable."""
+    try:
+        from magi_attention.api.magi_attn_interface import dist_attn_runtime_dict_mgr
+
+        return len(dist_attn_runtime_dict_mgr.keys(cp_group))
+    except Exception:
+        return 0
+
+
+def _magi_lru_clear(cp_group):
+    """Clear Magi's per-cp_group LRU."""
+    try:
+        from magi_attention.api.magi_attn_interface import clear_cache
+
+        clear_cache(cp_group)
+    except Exception as e:
+        print(f"[MULTI] WARN: clear_cache failed: {e}")
+
+
+def _profile_multi_forward(
+    label: str,
+    model,
+    cp_group,
+    forward_kind: str,  # "tree" or "dense_packed"
+    n_iters: int,
+    response_lengths: list[int],
+    clear_lru: bool = False,
+):
+    """Run n_iters forward+backward with varying response lengths to expose
+    LRU / persistent-state memory accumulation. Reports peak memory growth
+    across iterations + Magi LRU size after each iter.
+
+    forward_kind:
+      "tree":          builds a fresh Magi key per iter (registers in Magi LRU)
+      "dense_packed":  FA2 packed forward, no persistent state
+
+    clear_lru: when True, call magi_attention.api.clear_cache after each iter
+        to test whether LRU accumulation drives the peak growth.
+    """
+    torch.cuda.empty_cache()
+    if forward_kind == "tree":
+        _magi_lru_clear(cp_group)  # start fresh
+
+    torch.cuda.reset_peak_memory_stats()
+    base = torch.cuda.memory_allocated() / 1e9
+    print(f"[MULTI] {label}: baseline allocated = {base:.2f} GB,  clear_lru = {clear_lru}")
+    print(
+        f"[MULTI] {label}: running {n_iters} iters, response lengths = "
+        f"[{min(response_lengths)}..{max(response_lengths)}]"
+    )
+    print(f"[MULTI] {'iter':>5} {'resp_len':>10} {'peak_GB':>10} {'final_GB':>10} {'delta_GB':>10} {'magi_lru':>10}")
+    print("-" * 70)
+
+    peaks: list[float] = []
+    finals: list[float] = []
+    for i, r_len in enumerate(response_lengths):
+        samples, nested = _build_batch(model, response_len=r_len)
+        model.zero_grad(set_to_none=True)
+        torch.cuda.reset_peak_memory_stats()
+
+        if forward_kind == "tree":
+            per_sample = _tree_forward(model, nested, cp_group)
+        elif forward_kind == "dense_packed":
+            per_sample = _dense_forward_packed(model, samples)
+        else:
+            raise ValueError(f"unknown forward_kind={forward_kind}")
+        loss = _loss(per_sample, samples)
+        loss.backward()
+        torch.cuda.synchronize()
+
+        peak = torch.cuda.max_memory_allocated() / 1e9
+        final = torch.cuda.memory_allocated() / 1e9
+        lru_size = _magi_lru_size(cp_group)
+        peaks.append(peak)
+        finals.append(final)
+        delta = (peaks[i] - peaks[0]) if i > 0 else 0.0
+        print(f"[MULTI] {i:>5} {r_len:>10} {peak:>10.2f} {final:>10.2f} {delta:>+10.2f} {lru_size:>10}")
+
+        if clear_lru and forward_kind == "tree":
+            _magi_lru_clear(cp_group)
+            torch.cuda.empty_cache()
+
+    print(
+        f"[MULTI] {label}: peak growth iter[0]→iter[-1] = "
+        f"{peaks[-1] - peaks[0]:+.2f} GB ({peaks[0]:.2f} → {peaks[-1]:.2f})"
+    )
+    return peaks, finals
+
+
+def _profile_one(label: str, fwd_fn, samples, output_path: str):
+    """Record one forward+backward with memory history → dump snapshot pickle."""
+    # Reset baseline so peak is for THIS forward only
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    base = torch.cuda.memory_allocated() / 1e9
+    print(f"[PROFILE] {label}: baseline allocated = {base:.2f} GB")
+
+    # Start recording history (each allocation + free with stack)
+    torch.cuda.memory._record_memory_history(max_entries=200_000)
+
+    per_sample = fwd_fn()
+    loss = _loss(per_sample, samples)
+    loss.backward()
+
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated() / 1e9
+    final = torch.cuda.memory_allocated() / 1e9
+    print(f"[PROFILE] {label}: peak={peak:.2f} GB  final={final:.2f} GB  (loss={loss.item():.4f})")
+
+    # Dump snapshot for memory_viz
+    torch.cuda.memory._dump_snapshot(output_path)
+    print(f"[PROFILE] {label}: snapshot → {output_path}")
+    torch.cuda.memory._record_memory_history(enabled=None)
+
+
+def main() -> int:
+    _init_dist()
+    cp_group = dist.group.WORLD
+
+    model_path = os.environ.get("MODEL_PATH", os.path.expanduser("~/models/Qwen/Qwen2.5-3B-Instruct"))
+    print(f"[PROFILE] USE_FSDP={USE_FSDP}  N={N} P={P} R={R}")
+    print(f"[PROFILE] Loading {model_path}")
+    model = _load_model(model_path, cp_group)
+    samples, nested = _build_batch(model)
+    print(f"[PROFILE] total_tokens = {sum(s.shape[0] for s in samples)}, prefix_shared = {P * (N - 1)}")
+    print()
+
+    # ── Multi-forward LRU-accumulation test (env: MULTI_N) — if set, runs that
+    # many forward+backward iters with varying response lengths to expose any
+    # persistent state (Magi LRU mgr cache, FSDP buffers, etc.) that grows
+    # across iters. Mimics what a real training step does (~96 forwards
+    # over 32 distinct micro-batch shapes).
+    multi_n = int(os.environ.get("MULTI_N", "0"))
+    if multi_n > 0:
+        # Spread response lengths: 100..700 in N steps (matches GSM8K's
+        # observed response_length min/max range from R2_tree run)
+        lo, hi = 100, 700
+        if multi_n == 1:
+            response_lengths = [R]
+        else:
+            step = (hi - lo) // (multi_n - 1)
+            response_lengths = [lo + step * i for i in range(multi_n)]
+
+        # ── A: tree path with LRU left intact (method 1 — measure accumulation)
+        print("=" * 70)
+        print(f"[PROFILE] A: tree path, {multi_n} iters, LRU INTACT (measures accumulation)")
+        print("=" * 70)
+        model.config._attn_implementation = "Magi_Attention"
+        peaks_tree_keep, _ = _profile_multi_forward(
+            "tree_lru_keep", model, cp_group, "tree", multi_n, response_lengths, clear_lru=False
+        )
+        print()
+
+        # ── B: tree path with LRU cleared after each iter (method 3 — test the fix)
+        print("=" * 70)
+        print(f"[PROFILE] B: tree path, {multi_n} iters, LRU CLEARED after each iter")
+        print("=" * 70)
+        model.config._attn_implementation = "Magi_Attention"
+        peaks_tree_clear, _ = _profile_multi_forward(
+            "tree_lru_clear", model, cp_group, "tree", multi_n, response_lengths, clear_lru=True
+        )
+        print()
+
+        # ── C: dense packed baseline
+        print("=" * 70)
+        print(f"[PROFILE] C: dense packed path, {multi_n} iters (no LRU, sanity baseline)")
+        print("=" * 70)
+        model.config._attn_implementation = "flash_attention_2"
+        peaks_dense, _ = _profile_multi_forward(
+            "dense", model, cp_group, "dense_packed", multi_n, response_lengths, clear_lru=False
+        )
+        print()
+
+        # ── Summary table
+        print("=" * 70)
+        print("[PROFILE] SUMMARY")
+        print("=" * 70)
+        print(f"{'condition':<25} {'iter[0] peak':>15} {'iter[-1] peak':>15} {'growth':>10}")
+        print("-" * 70)
+        for cond, peaks in [
+            ("tree (LRU intact)", peaks_tree_keep),
+            ("tree (LRU cleared)", peaks_tree_clear),
+            ("dense packed", peaks_dense),
+        ]:
+            growth = peaks[-1] - peaks[0]
+            print(f"{cond:<25} {peaks[0]:>15.2f} {peaks[-1]:>15.2f} {growth:>+10.2f}")
+        print()
+        print("[PROFILE] Hypothesis check:")
+        print("  - LRU accumulation drives peak ⇔ tree(intact).growth >> tree(cleared).growth")
+        print("  - dense.growth should ≈ 0 (no persistent state)")
+
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        return 0
+
+    # ── Tree path
+    print("=" * 70)
+    print("[PROFILE] Tree (dynamic-trie + Magi) forward + backward")
+    print("=" * 70)
+    model.zero_grad(set_to_none=True)
+    model.config._attn_implementation = "Magi_Attention"
+    _profile_one(
+        "tree",
+        lambda: _tree_forward(model, nested, cp_group),
+        samples,
+        "/tmp/profile_tree_memory.pickle",
+    )
+    print()
+
+    # ── Dense packed (FA2) — what verl ACTUALLY uses in training
+    print("=" * 70)
+    print("[PROFILE] Dense packed (FA2 rmpad) forward + backward — production-equivalent")
+    print("=" * 70)
+    model.zero_grad(set_to_none=True)
+    # Set FA2 BEFORE forward and keep through backward — grad ckpt recompute
+    # must see the same _attn_implementation as the original forward.
+    model.config._attn_implementation = "flash_attention_2"
+    _profile_one(
+        "dense_packed",
+        lambda: _dense_forward_packed(model, samples),
+        samples,
+        "/tmp/profile_dense_packed_memory.pickle",
+    )
+    print()
+
+    # ── Dense per-sample (sdpa) — kept as reference, NOT production
+    if os.environ.get("ALSO_DENSE_PER_SAMPLE", "0") == "1":
+        print("=" * 70)
+        print("[PROFILE] Dense per-sample sdpa forward + backward (reference, NOT production)")
+        print("=" * 70)
+        model.zero_grad(set_to_none=True)
+        model.config._attn_implementation = "sdpa"
+        _profile_one(
+            "dense_per_sample",
+            lambda: _dense_forward_per_sample(model, samples),
+            samples,
+            "/tmp/profile_dense_per_sample_memory.pickle",
+        )
+
+    print()
+    print("=" * 70)
+    print("[PROFILE] DONE. Upload to https://pytorch.org/memory_viz :")
+    print("           /tmp/profile_tree_memory.pickle         (tree packed Magi)")
+    print("           /tmp/profile_dense_packed_memory.pickle (production-equivalent dense)")
+    if os.environ.get("ALSO_DENSE_PER_SAMPLE", "0") == "1":
+        print("           /tmp/profile_dense_per_sample_memory.pickle (reference, per-sample sdpa)")
+    print("=" * 70)
+    print(
+        "[PROFILE] NOTE: tree-vs-dense_packed is the comparison that matches the "
+        "8×H100 training observation (16.6 vs 11.7 GB per rank)."
+    )
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prefix_script/fsdp/run_dense_only.sh
+++ b/prefix_script/fsdp/run_dense_only.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Single-run dense baseline (R1: use_prefix_tree_dynamic=False).
+# Companion to run_tree_only.sh.
+#
+# Usage:
+#   bash prefix_script/fsdp/run_dense_only.sh                  # default STEPS=100
+#   STEPS=50 bash prefix_script/fsdp/run_dense_only.sh
+#   USE_WANDB=0 bash prefix_script/fsdp/run_dense_only.sh
+#   EXTRA_ARGS='actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8' \
+#       bash prefix_script/fsdp/run_dense_only.sh              # extra hydra overrides
+#
+set -ex
+
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/Qwen/Qwen2.5-3B-Instruct}
+DATA_DIR=${DATA_DIR:-${HOME}/data/gsm8k}
+LOG_ROOT=${LOG_ROOT:-/root/convergence_logs}
+STEPS=${STEPS:-100}
+SEED=${SEED:-42}
+N_GPUS=${N_GPUS:-8}
+USE_WANDB=${USE_WANDB:-1}
+WANDB_PROJECT=${WANDB_PROJECT:-tree_training_convergence_e2e}
+EXPERIMENT_NAME=${EXPERIMENT_NAME:-R1_dense_${STEPS}step}
+
+mkdir -p "$LOG_ROOT"
+LOG_FILE="$LOG_ROOT/${EXPERIMENT_NAME}.log"
+
+if [ "$USE_WANDB" = "1" ]; then
+    LOGGER_ARG=("trainer.logger=[console,wandb]")
+else
+    LOGGER_ARG=("trainer.logger=console")
+fi
+
+EXTRA_ARGS=${EXTRA_ARGS:-}
+read -ra EXTRA_ARGS_ARR <<< "$EXTRA_ARGS"
+
+export NCCL_NVLS_ENABLE=0
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files="$DATA_DIR/train.parquet" \
+    data.val_files="$DATA_DIR/test.parquet" \
+    data.train_batch_size=32 \
+    data.max_prompt_length=512 \
+    data.max_response_length=1024 \
+    data.filter_overlong_prompts=True \
+    data.truncation=error \
+    actor_rollout_ref.model.path="$MODEL_PATH" \
+    actor_rollout_ref.actor.optim.lr=5e-7 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=32 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.use_dynamic_bsz=False \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.ref.use_torch_compile=False \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False \
+    actor_rollout_ref.ref.fsdp_config.param_offload=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.n=8 \
+    algorithm.kl_ctrl.kl_coef=0.001 \
+    actor_rollout_ref.actor.use_prefix_tree_dynamic=False \
+    trainer.critic_warmup=0 \
+    "${LOGGER_ARG[@]}" \
+    trainer.project_name="$WANDB_PROJECT" \
+    trainer.experiment_name="$EXPERIMENT_NAME" \
+    trainer.n_gpus_per_node=$N_GPUS \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=$STEPS \
+    +trainer.seed=$SEED \
+    "${EXTRA_ARGS_ARR[@]}" \
+    2>&1 | tee "$LOG_FILE"
+
+echo ""
+echo "=========================================="
+echo "[DENSE] DONE — log: $LOG_FILE"
+echo "[DENSE] wandb run: $WANDB_PROJECT / $EXPERIMENT_NAME"
+echo "=========================================="

--- a/prefix_script/fsdp/run_e2e_convergence.sh
+++ b/prefix_script/fsdp/run_e2e_convergence.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# E2E convergence test for dynamic prefix-tree + Magi on FSDP2.
+#
+# Runs 3 training jobs (same seed, same hyperparams) and compares step-by-step
+# metrics:
+#
+#   R1 dense                  : use_prefix_tree_dynamic=False (ground truth)
+#   R2 tree non-CP            : use_prefix_tree_dynamic=True, context_parallel_size=1
+#   R3 tree CP=2              : use_prefix_tree_dynamic=True, context_parallel_size=2
+#
+# Then compares R2 vs R1 (non-CP convergence) and R3 vs R1 (CP=2 convergence)
+# via prefix_script/fsdp/compare_training_metrics.py.
+#
+# Stack: Qwen2.5-3B-Instruct + GSM8K + GRPO + FSDP2 + Magi FFA + vLLM.
+# Hardware: 8×H100 (single node), ~2.5-3 hr total for STEPS=150.
+#
+# Usage:
+#   bash prefix_script/fsdp/run_e2e_convergence.sh
+#   STEPS=10 bash prefix_script/fsdp/run_e2e_convergence.sh   # smoke
+#   SKIP_R3=1 bash prefix_script/fsdp/run_e2e_convergence.sh  # skip CP run
+#   USE_WANDB=1 bash prefix_script/fsdp/run_e2e_convergence.sh # also log to wandb
+#       (requires `wandb login` or WANDB_API_KEY env; wandb project name
+#        = $WANDB_PROJECT, default 'tree_training_convergence_e2e')
+#
+set -ex
+
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-3B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/${MODEL_ID}}
+DATA_DIR=${DATA_DIR:-${HOME}/data/gsm8k}
+LOG_DIR=${LOG_DIR:-$(mktemp -d /tmp/convergence_e2e.XXXXXX)}
+
+USE_WANDB=${USE_WANDB:-0}
+WANDB_PROJECT=${WANDB_PROJECT:-tree_training_convergence_e2e}
+if [ "$USE_WANDB" = "1" ]; then
+    # console kept so compare_training_metrics.py can still parse step lines
+    LOGGER_ARG=("trainer.logger=[console,wandb]")
+else
+    LOGGER_ARG=("trainer.logger=console")
+fi
+
+STEPS=${STEPS:-150}
+ROLLOUT_N=${ROLLOUT_N:-8}
+SEED=${SEED:-42}
+N_GPUS=${N_GPUS:-8}
+SKIP_R3=${SKIP_R3:-0}
+
+echo "=========================================="
+echo "[E2E] Convergence test: dynamic prefix-tree + Magi vs dense"
+echo "[E2E]   model:   $MODEL_PATH"
+echo "[E2E]   data:    $DATA_DIR"
+echo "[E2E]   steps:   $STEPS    rollout_n: $ROLLOUT_N    seed: $SEED"
+echo "[E2E]   N_GPUS:  $N_GPUS"
+echo "[E2E]   logs:    $LOG_DIR"
+echo "=========================================="
+
+# ----------------------------------------------------------------------------
+# Common config — IDENTICAL across all 3 runs so the only varying knob is
+# (use_prefix_tree_dynamic, context_parallel_size). Critical points:
+#   - use_dynamic_bsz=False: stable per-step token budget, so micro-batch shapes
+#     match exactly across runs
+#   - ulysses_sequence_parallel_size=1: Magi CP and Ulysses SP are mutually
+#     exclusive (see FSDPEngine._init_device_mesh assertion). All 3 runs use
+#     ulysses_sp=1 so the dense baseline matches the tree runs' parallel layout.
+#   - strategy=fsdp2 (top-level actor.strategy): dynamic + Magi REQUIRES FSDP2;
+#     ActorConfig.__post_init__ syncs top-level into engine.strategy.
+#   - +trainer.seed=$SEED: enforces deterministic rollout sampling order.
+# ----------------------------------------------------------------------------
+COMMON_ARGS=(
+    algorithm.adv_estimator=grpo
+    data.train_files="$DATA_DIR/train.parquet"
+    data.val_files="$DATA_DIR/test.parquet"
+    data.train_batch_size=32
+    data.max_prompt_length=512
+    data.max_response_length=1024
+    data.filter_overlong_prompts=True
+    data.truncation=error
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.actor.optim.lr=5e-7
+    actor_rollout_ref.actor.ppo_mini_batch_size=32
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=2
+    actor_rollout_ref.actor.use_kl_loss=True
+    actor_rollout_ref.actor.kl_loss_coef=0.001
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl
+    actor_rollout_ref.actor.use_dynamic_bsz=False
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=1
+    actor_rollout_ref.actor.strategy=fsdp2
+    actor_rollout_ref.actor.fsdp_config.param_offload=False
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False
+    actor_rollout_ref.actor.use_torch_compile=False
+    actor_rollout_ref.ref.use_torch_compile=False
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=2
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False
+    actor_rollout_ref.ref.fsdp_config.param_offload=False
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=2
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4
+    actor_rollout_ref.rollout.n=$ROLLOUT_N
+    algorithm.kl_ctrl.kl_coef=0.001
+    trainer.critic_warmup=0
+    "${LOGGER_ARG[@]}"
+    trainer.project_name=$WANDB_PROJECT
+    trainer.n_gpus_per_node=$N_GPUS
+    trainer.nnodes=1
+    trainer.save_freq=-1
+    trainer.test_freq=-1
+    trainer.total_epochs=1
+    trainer.total_training_steps=$STEPS
+    +trainer.seed=$SEED
+)
+
+# ----------------------------------------------------------------------------
+# Run order: tree runs FIRST so we fail fast on tree-side bugs without
+# spending baseline GPU-time. Dense baseline runs last; without it we still
+# know whether the tree path itself trained successfully.
+# ----------------------------------------------------------------------------
+
+# R2: Tree non-CP. use_prefix_tree_dynamic=True (cp_size=1).
+echo ""
+echo "=========================================="
+echo "[E2E] R2: Tree non-CP (use_prefix_tree_dynamic=True, cp_size=1)"
+echo "=========================================="
+python3 -m verl.trainer.main_ppo \
+    "${COMMON_ARGS[@]}" \
+    actor_rollout_ref.actor.use_prefix_tree_dynamic=True \
+    actor_rollout_ref.actor.prefix_tree_attention=magi \
+    actor_rollout_ref.actor.context_parallel_size=1 \
+    trainer.experiment_name=R2_tree_noncp \
+    2>&1 | tee "$LOG_DIR/R2_tree_noncp.log"
+
+# R3: Tree CP=2. context_parallel_size=2 (8 GPU = 4 DP × 2 CP).
+if [ "$SKIP_R3" != "1" ]; then
+    echo ""
+    echo "=========================================="
+    echo "[E2E] R3: Tree CP=2 (use_prefix_tree_dynamic=True, cp_size=2)"
+    echo "=========================================="
+    python3 -m verl.trainer.main_ppo \
+        "${COMMON_ARGS[@]}" \
+        actor_rollout_ref.actor.use_prefix_tree_dynamic=True \
+        actor_rollout_ref.actor.prefix_tree_attention=magi \
+        actor_rollout_ref.actor.context_parallel_size=2 \
+        trainer.experiment_name=R3_tree_cp2 \
+        2>&1 | tee "$LOG_DIR/R3_tree_cp2.log"
+fi
+
+# R1: Dense baseline (no prefix tree). The "gold ground truth" trajectory,
+# run last because the tree runs above are what we're actually validating.
+echo ""
+echo "=========================================="
+echo "[E2E] R1: Dense baseline (no prefix tree)"
+echo "=========================================="
+python3 -m verl.trainer.main_ppo \
+    "${COMMON_ARGS[@]}" \
+    actor_rollout_ref.actor.use_prefix_tree_dynamic=False \
+    trainer.experiment_name=R1_dense \
+    2>&1 | tee "$LOG_DIR/R1_dense.log"
+
+# ----------------------------------------------------------------------------
+# Compare: R2 vs R1 (non-CP convergence), R3 vs R1 (CP convergence)
+# ----------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "[E2E] Comparing metrics: R2 (tree non-CP) vs R1 (dense)"
+echo "=========================================="
+python3 prefix_script/fsdp/compare_training_metrics.py \
+    --baseline_log "$LOG_DIR/R1_dense.log" \
+    --treatment_log "$LOG_DIR/R2_tree_noncp.log" \
+    --label "R2 tree non-CP vs R1 dense" \
+    --output "$LOG_DIR/compare_R2_vs_R1.json"
+RC_R2=$?
+
+RC_R3=0
+if [ "$SKIP_R3" != "1" ]; then
+    echo ""
+    echo "=========================================="
+    echo "[E2E] Comparing metrics: R3 (tree CP=2) vs R1 (dense)"
+    echo "=========================================="
+    python3 prefix_script/fsdp/compare_training_metrics.py \
+        --baseline_log "$LOG_DIR/R1_dense.log" \
+        --treatment_log "$LOG_DIR/R3_tree_cp2.log" \
+        --label "R3 tree CP=2 vs R1 dense" \
+        --output "$LOG_DIR/compare_R3_vs_R1.json"
+    RC_R3=$?
+fi
+
+echo ""
+echo "=========================================="
+echo "[E2E] DONE — logs + JSON in $LOG_DIR"
+echo "=========================================="
+if [ $RC_R2 -eq 0 ] && [ $RC_R3 -eq 0 ]; then
+    echo "[E2E] OVERALL: PASS"
+    exit 0
+else
+    echo "[E2E] OVERALL: FAIL (RC_R2=$RC_R2 RC_R3=$RC_R3)"
+    exit 1
+fi

--- a/prefix_script/fsdp/run_grpo_dynamic_prefix_tree.sh
+++ b/prefix_script/fsdp/run_grpo_dynamic_prefix_tree.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# E2E correctness test for dynamic prefix-tree + Magi attention on FSDP.
+# Stack: Qwen2.5-0.5B-Instruct + GSM8K + GRPO + FSDP + Magi FFA + vLLM.
+#
+# Strategy: two short training runs (~10 steps each), identical seed and config,
+# one with use_prefix_tree_dynamic=true and one without. Compare reward trajectories
+# — dynamic-trie + Magi should track the dense baseline within tolerance.
+#
+# Hardware:
+#   - CP_SIZE=1 → 1× H100, ~10-15 min (single-rank Magi, no dispatch)
+#   - CP_SIZE=2 → 2× H100, ~10-15 min (real Magi CP dispatch)
+#
+# Usage:
+#   bash prefix_script/fsdp/run_grpo_dynamic_prefix_tree.sh                       # cp=1
+#   CP_SIZE=2 N_GPUS=2 bash prefix_script/fsdp/run_grpo_dynamic_prefix_tree.sh    # cp=2
+#   TOTAL_STEPS=20 ROLLOUT_N=4 bash prefix_script/fsdp/run_grpo_dynamic_prefix_tree.sh
+set -ex
+
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/${MODEL_ID}}
+DATA_DIR=${DATA_DIR:-${HOME}/data/gsm8k}
+LOG_DIR=${LOG_DIR:-$(mktemp -d /tmp/dynamic_prefix_tree_e2e.XXXXXX)}
+echo "[E2E] Logs → $LOG_DIR"
+
+TOTAL_STEPS=${TOTAL_STEPS:-10}
+ROLLOUT_N=${ROLLOUT_N:-8}
+SEED=${SEED:-42}
+CP_SIZE=${CP_SIZE:-1}            # Magi context parallel size (1, 2, 4, ...)
+N_GPUS=${N_GPUS:-${CP_SIZE}}     # GPUs per node — must be >= CP_SIZE
+SKIP_BASELINE=${SKIP_BASELINE:-0}  # 1 = skip dense baseline run (debug iteration speedup)
+ENABLE_GC=${ENABLE_GC:-1}          # 1 = enable gradient checkpointing (default), 0 = disable for ppo_kl debug
+
+# Common Hydra args shared by both runs.
+# Notes:
+#   - use_dynamic_bsz=False keeps per-step token budget stable, so the two runs
+#     see the same micro-batch shapes (any reward divergence is attributable to
+#     the prefix-tree forward, not batching).
+#   - ulysses_sequence_parallel_size=1 because dynamic-trie + Magi+CP is mutually exclusive
+#     with Ulysses SP (see FSDPEngine._init_device_mesh assertion).
+#   - rollout.n=$ROLLOUT_N gives each prompt N rollouts that share a prefix,
+#     which is exactly the shape dynamic prefix tree accelerates.
+COMMON_ARGS=(
+    algorithm.adv_estimator=grpo
+    data.train_files=$DATA_DIR/train.parquet
+    data.val_files=$DATA_DIR/test.parquet
+    data.train_batch_size=8
+    data.max_prompt_length=512
+    data.max_response_length=256
+    data.filter_overlong_prompts=True
+    data.truncation=error
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.actor.optim.lr=5e-7
+    actor_rollout_ref.actor.ppo_mini_batch_size=8
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4
+    actor_rollout_ref.actor.use_kl_loss=True
+    actor_rollout_ref.actor.kl_loss_coef=0.001
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl
+    actor_rollout_ref.actor.use_dynamic_bsz=False
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=1
+    # dynamic-trie + Magi REQUIRES FSDP2 — FSDP1 produces EVAL/TRAIN forward divergence,
+    # see verl/workers/engine/fsdp/transformer_impl.py:_build_module assert.
+    # NOTE: must set TOP-LEVEL actor.strategy (not engine.strategy). ActorConfig
+    # __post_init__ syncs top-level → engine.strategy, so any "+engine.strategy"
+    # override gets clobbered. ref.strategy inherits from actor via OmegaConf.
+    actor_rollout_ref.actor.strategy=fsdp2
+    actor_rollout_ref.actor.fsdp_config.param_offload=False
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False
+    actor_rollout_ref.actor.use_torch_compile=False
+    actor_rollout_ref.ref.use_torch_compile=False
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=4
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4
+    actor_rollout_ref.rollout.n=$ROLLOUT_N
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False
+    actor_rollout_ref.ref.fsdp_config.param_offload=False
+    algorithm.kl_ctrl.kl_coef=0.001
+    trainer.critic_warmup=0
+    trainer.logger=console
+    trainer.project_name=dynamic_prefix_tree_e2e
+    trainer.n_gpus_per_node=$N_GPUS
+    trainer.nnodes=1
+    trainer.save_freq=-1
+    trainer.test_freq=-1
+    trainer.total_epochs=1
+    trainer.total_training_steps=$TOTAL_STEPS
+    +trainer.seed=$SEED
+)
+
+# bf16 override knob (debug). Setting these CAN trigger a hang at ref's first
+# forward, suspected NCCL/Magi cp_group interaction. Leave disabled by default
+# until root cause is understood.
+if [ "${FORCE_BF16:-0}" = "1" ]; then
+    COMMON_ARGS+=(
+        +actor_rollout_ref.actor.engine.model_dtype=bfloat16
+        +actor_rollout_ref.ref.engine.model_dtype=bfloat16
+    )
+    echo "[E2E] WARNING: FORCE_BF16=1, model_dtype=bfloat16. May hang."
+fi
+
+# Gradient checkpointing toggle (debug knob for ppo_kl mismatch investigation)
+if [ "$ENABLE_GC" = "0" ]; then
+    COMMON_ARGS+=(actor_rollout_ref.model.enable_gradient_checkpointing=False)
+    echo "[E2E] gradient_checkpointing DISABLED (ENABLE_GC=0)"
+fi
+
+echo "=========================================="
+echo "[E2E] RUN 1: dynamic prefix tree + Magi (cp=${CP_SIZE})"
+echo "=========================================="
+# ref inherits use_prefix_tree_dynamic/prefix_tree_attention/context_parallel_size
+# from actor automatically (see verl/trainer/config/ref/ref.yaml).
+python3 -m verl.trainer.main_ppo \
+    "${COMMON_ARGS[@]}" \
+    actor_rollout_ref.actor.use_prefix_tree_dynamic=True \
+    actor_rollout_ref.actor.prefix_tree_attention=magi \
+    actor_rollout_ref.actor.context_parallel_size=$CP_SIZE \
+    trainer.experiment_name=qwen2_5_05b_grpo_dynamic_magi_cp${CP_SIZE} \
+    2>&1 | tee "$LOG_DIR/dyn.log"
+
+if [ "$SKIP_BASELINE" = "1" ]; then
+    echo "=========================================="
+    echo "[E2E] SKIP_BASELINE=1 → skipping dense baseline run"
+    echo "[E2E] dynamic-trie + Magi log: $LOG_DIR/dyn.log"
+    echo "=========================================="
+    exit 0
+fi
+
+echo "=========================================="
+echo "[E2E] RUN 2: Dense baseline (no prefix tree)"
+echo "=========================================="
+python3 -m verl.trainer.main_ppo \
+    "${COMMON_ARGS[@]}" \
+    actor_rollout_ref.actor.use_prefix_tree_dynamic=False \
+    trainer.experiment_name=qwen2_5_05b_grpo_dense \
+    2>&1 | tee "$LOG_DIR/dense.log"
+
+echo "[E2E] Both runs completed — log dir: $LOG_DIR"
+echo "[E2E]   dynamic-trie + Magi: $LOG_DIR/dyn.log"
+echo "[E2E]   dense baseline:      $LOG_DIR/dense.log"

--- a/prefix_script/fsdp/run_memlog_diag.sh
+++ b/prefix_script/fsdp/run_memlog_diag.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Memory diagnostic: runs a short tree + dense training (default 8×H100,
+# 2 steps each) with PROFILE_MEMORY_LOG=1 enabled in forward_step. Prints
+# a comparison at the end so we can see whether the 5GB per-rank delta
+# observed in production training shows up here, and if so, whether it's
+# inside forward_step or outside.
+#
+# Usage:
+#   bash prefix_script/fsdp/run_memlog_diag.sh                # 8 GPU, 2 step
+#   N_GPUS=1 bash prefix_script/fsdp/run_memlog_diag.sh       # 1 GPU diagnostic
+#   STEPS=3 bash prefix_script/fsdp/run_memlog_diag.sh        # more steps
+#   ONLY=tree bash prefix_script/fsdp/run_memlog_diag.sh      # skip dense
+#   ONLY=dense bash prefix_script/fsdp/run_memlog_diag.sh     # skip tree
+#
+set -eu
+
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/Qwen/Qwen2.5-3B-Instruct}
+DATA_DIR=${DATA_DIR:-${HOME}/data/gsm8k}
+LOG_ROOT=${LOG_ROOT:-/root/convergence_logs}
+STEPS=${STEPS:-2}
+N_GPUS=${N_GPUS:-8}
+SEED=${SEED:-42}
+ONLY=${ONLY:-both}   # tree | dense | both
+
+# Batch size auto-scales with N_GPUS so workload per rank stays at 8 samples.
+# With rollout.n=8, each rank gets one prompt × 8 rollouts = 8 samples per
+# micro-batch, which is the configuration that exposes tree's prefix sharing.
+BATCH=${BATCH:-$((N_GPUS * 8 / 8))}   # = N_GPUS prompts per step
+[ "$BATCH" -lt 1 ] && BATCH=1
+
+mkdir -p "$LOG_ROOT"
+
+export NCCL_NVLS_ENABLE=0
+
+_COMMON_ARGS=(
+    algorithm.adv_estimator=grpo
+    data.train_files="$DATA_DIR/train.parquet"
+    data.val_files="$DATA_DIR/test.parquet"
+    data.train_batch_size=$BATCH
+    data.max_prompt_length=512
+    data.max_response_length=1024
+    data.filter_overlong_prompts=True
+    data.truncation=error
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.actor.optim.lr=5e-7
+    actor_rollout_ref.actor.ppo_mini_batch_size=$BATCH
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8
+    actor_rollout_ref.actor.use_kl_loss=True
+    actor_rollout_ref.actor.kl_loss_coef=0.001
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl
+    actor_rollout_ref.actor.use_dynamic_bsz=False
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=1
+    actor_rollout_ref.actor.strategy=fsdp2
+    actor_rollout_ref.actor.fsdp_config.param_offload=False
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False
+    actor_rollout_ref.actor.use_torch_compile=False
+    actor_rollout_ref.ref.use_torch_compile=False
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False
+    actor_rollout_ref.ref.fsdp_config.param_offload=False
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4
+    actor_rollout_ref.rollout.n=8
+    algorithm.kl_ctrl.kl_coef=0.001
+    trainer.critic_warmup=0
+    trainer.logger=console
+    trainer.project_name=mem_diag
+    trainer.n_gpus_per_node=$N_GPUS
+    trainer.nnodes=1
+    trainer.save_freq=-1
+    trainer.test_freq=-1
+    trainer.total_epochs=1
+    trainer.total_training_steps=$STEPS
+    +trainer.seed=$SEED
+)
+
+# ----------------------------------------------------------------------------
+# Run a single training (tree or dense) with mem logging on
+# ----------------------------------------------------------------------------
+_run_one() {
+    local mode=$1
+    local exp_name=$2
+    local log_file=$3
+
+    echo ""
+    echo "=========================================="
+    echo "[MEMLOG] $mode: $exp_name → $log_file"
+    echo "[MEMLOG]   N_GPUS=$N_GPUS  BATCH=$BATCH  STEPS=$STEPS"
+    echo "=========================================="
+
+    local tree_args=()
+    if [ "$mode" = "tree" ]; then
+        tree_args=(
+            actor_rollout_ref.actor.use_prefix_tree_dynamic=True
+            actor_rollout_ref.actor.prefix_tree_attention=magi
+            actor_rollout_ref.actor.context_parallel_size=1
+        )
+    else
+        tree_args=(
+            actor_rollout_ref.actor.use_prefix_tree_dynamic=False
+        )
+    fi
+
+    PROFILE_MEMORY_LOG=1 python3 -m verl.trainer.main_ppo \
+        "${_COMMON_ARGS[@]}" \
+        "${tree_args[@]}" \
+        trainer.experiment_name="$exp_name" \
+        2>&1 | tee "$log_file"
+}
+
+# ----------------------------------------------------------------------------
+# Extract per-run summary from log
+# ----------------------------------------------------------------------------
+_summarize_run() {
+    local label=$1
+    local log_file=$2
+
+    echo ""
+    echo "----- $label  ($log_file) -----"
+
+    # 1) Top-level max_memory_allocated_gb across all training steps
+    echo "[$label] actor/perf/max_memory_allocated_gb per step:"
+    grep -oE "step:[0-9]+ -" "$log_file" | head -5
+    grep -oE "actor/perf/max_memory_allocated_gb:np\.float64\([0-9.]+\)" "$log_file" \
+        | sed 's/.*(\(.*\)).*/  \1 GB/'
+
+    # 2) forward_step internal peaks (unique sorted)
+    echo "[$label] forward_step internal peak GB (unique, sorted):"
+    grep "\[MEM\]" "$log_file" | awk '{print $NF}' | sort -u | sed 's/peak=/  /'
+
+    # 3) prefix_tree token ratio (tree only)
+    if grep -q "prefix_tree/token_ratio" "$log_file" 2>/dev/null; then
+        echo "[$label] prefix_tree/token_ratio per step:"
+        grep -oE "prefix_tree/token_ratio:np\.float64\([0-9.]+\)" "$log_file" \
+            | sed 's/.*(\(.*\)).*/  \1/'
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+TREE_LOG="$LOG_ROOT/R2_tree_memlog_${N_GPUS}gpu.log"
+DENSE_LOG="$LOG_ROOT/R1_dense_memlog_${N_GPUS}gpu.log"
+
+if [ "$ONLY" = "tree" ] || [ "$ONLY" = "both" ]; then
+    _run_one tree "R2_tree_memlog_${N_GPUS}gpu" "$TREE_LOG"
+fi
+
+if [ "$ONLY" = "dense" ] || [ "$ONLY" = "both" ]; then
+    _run_one dense "R1_dense_memlog_${N_GPUS}gpu" "$DENSE_LOG"
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "[MEMLOG] SUMMARY"
+echo "=========================================="
+
+[ "$ONLY" != "dense" ] && _summarize_run "TREE" "$TREE_LOG"
+[ "$ONLY" != "tree" ]  && _summarize_run "DENSE" "$DENSE_LOG"
+
+echo ""
+echo "=========================================="
+echo "[MEMLOG] DONE — full logs at:"
+[ "$ONLY" != "dense" ] && echo "  $TREE_LOG"
+[ "$ONLY" != "tree" ]  && echo "  $DENSE_LOG"
+echo "=========================================="

--- a/prefix_script/fsdp/run_tree_only.sh
+++ b/prefix_script/fsdp/run_tree_only.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Single-run tree-only convergence run (R2: use_prefix_tree_dynamic=True, cp=1).
+# Companion to run_dense_only.sh — pair the two to do a baseline-vs-tree comparison
+# without running them in one big serial script.
+#
+# Usage:
+#   bash prefix_script/fsdp/run_tree_only.sh                  # default STEPS=100
+#   STEPS=50 bash prefix_script/fsdp/run_tree_only.sh         # custom step count
+#   USE_WANDB=0 bash prefix_script/fsdp/run_tree_only.sh      # disable wandb
+#   EXTRA_ARGS='actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8' \
+#       bash prefix_script/fsdp/run_tree_only.sh              # extra hydra overrides
+#
+set -ex
+
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/Qwen/Qwen2.5-3B-Instruct}
+DATA_DIR=${DATA_DIR:-${HOME}/data/gsm8k}
+LOG_ROOT=${LOG_ROOT:-/root/convergence_logs}
+STEPS=${STEPS:-100}
+SEED=${SEED:-42}
+N_GPUS=${N_GPUS:-8}
+USE_WANDB=${USE_WANDB:-1}
+WANDB_PROJECT=${WANDB_PROJECT:-tree_training_convergence_e2e}
+EXPERIMENT_NAME=${EXPERIMENT_NAME:-R2_tree_noncp_${STEPS}step}
+
+mkdir -p "$LOG_ROOT"
+LOG_FILE="$LOG_ROOT/${EXPERIMENT_NAME}.log"
+
+if [ "$USE_WANDB" = "1" ]; then
+    LOGGER_ARG=("trainer.logger=[console,wandb]")
+else
+    LOGGER_ARG=("trainer.logger=console")
+fi
+
+# Caller-supplied extra hydra overrides, space-separated.
+# Example: EXTRA_ARGS='a=1 b=2 actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8'
+EXTRA_ARGS=${EXTRA_ARGS:-}
+read -ra EXTRA_ARGS_ARR <<< "$EXTRA_ARGS"
+
+export NCCL_NVLS_ENABLE=0
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files="$DATA_DIR/train.parquet" \
+    data.val_files="$DATA_DIR/test.parquet" \
+    data.train_batch_size=32 \
+    data.max_prompt_length=512 \
+    data.max_response_length=1024 \
+    data.filter_overlong_prompts=True \
+    data.truncation=error \
+    actor_rollout_ref.model.path="$MODEL_PATH" \
+    actor_rollout_ref.actor.optim.lr=5e-7 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=32 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.use_dynamic_bsz=False \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.ref.use_torch_compile=False \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False \
+    actor_rollout_ref.ref.fsdp_config.param_offload=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.n=8 \
+    algorithm.kl_ctrl.kl_coef=0.001 \
+    actor_rollout_ref.actor.use_prefix_tree_dynamic=True \
+    actor_rollout_ref.actor.prefix_tree_attention=magi \
+    actor_rollout_ref.actor.context_parallel_size=1 \
+    trainer.critic_warmup=0 \
+    "${LOGGER_ARG[@]}" \
+    trainer.project_name="$WANDB_PROJECT" \
+    trainer.experiment_name="$EXPERIMENT_NAME" \
+    trainer.n_gpus_per_node=$N_GPUS \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=$STEPS \
+    +trainer.seed=$SEED \
+    "${EXTRA_ARGS_ARR[@]}" \
+    2>&1 | tee "$LOG_FILE"
+
+echo ""
+echo "=========================================="
+echo "[TREE] DONE — log: $LOG_FILE"
+echo "[TREE] wandb run: $WANDB_PROJECT / $EXPERIMENT_NAME"
+echo "=========================================="

--- a/prefix_script/fsdp/sanity_dynamic_magi.py
+++ b/prefix_script/fsdp/sanity_dynamic_magi.py
@@ -1,0 +1,285 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""dynamic-trie + Magi single-GPU sanity: forward / backward equivalence + mode determinism.
+
+Three checks on a GRPO-style batch (1 prompt × N rollouts) using Qwen2.5-0.5B.
+Works for both plain HF (default) and FSDP2-wrapped models (``USE_FSDP=1``):
+
+  Check A — forward equivalence:
+      dynamic-trie + Magi packed forward vs dense (sdpa) per-sample forward must agree
+      within bf16 noise floor.
+
+  Check B — backward equivalence:
+      dynamic-trie + Magi loss.backward() vs dense loss.backward() must produce the
+      same grad_norm (relative diff within tolerance).
+
+  Check C — mode determinism (EVAL/TRAIN/EVAL):
+      dynamic-trie + Magi forward in {EVAL no_grad, TRAIN grad, EVAL no_grad again}
+      must produce identical outputs. Catches state leakage between
+      mode switches — originally the symptom that drove the LRU-order
+      investigation; now expected to be deterministic.
+
+Env tunables:
+  USE_FSDP=1       wrap the model in FSDP2 (matches production verl) —
+                   if you only have time for one sanity, use this one.
+  MODEL_PATH       HF model dir (default ~/models/Qwen/Qwen2.5-0.5B-Instruct)
+  N, P, R          rollouts / prompt-len / response-len (defaults 4/64/32)
+
+Usage:
+    torchrun --standalone --nproc_per_node=1 prefix_script/fsdp/sanity_dynamic_magi.py
+    USE_FSDP=1 torchrun --standalone --nproc_per_node=1 prefix_script/fsdp/sanity_dynamic_magi.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+N = int(os.environ.get("N", "4"))
+P = int(os.environ.get("P", "64"))
+R = int(os.environ.get("R", "32"))
+USE_FSDP = os.environ.get("USE_FSDP", "0") == "1"
+
+
+def _init_dist():
+    if not dist.is_initialized():
+        if "RANK" not in os.environ:
+            raise RuntimeError("Run via torchrun")
+        torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
+        dist.init_process_group(backend="nccl")
+
+
+def _build_fsdp_qwen(model_path):
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.fsdp import MixedPrecisionPolicy
+    from transformers import Qwen2ForCausalLM
+
+    from verl.utils.fsdp_utils import apply_fsdp2, fsdp2_load_full_state_dict
+
+    model = Qwen2ForCausalLM.from_pretrained(model_path, dtype=torch.float32).cuda()
+    world = dist.get_world_size()
+    mesh = init_device_mesh("cuda", mesh_shape=(world,), mesh_dim_names=("fsdp",))
+    mp = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16,
+        reduce_dtype=torch.float32,
+        cast_forward_inputs=True,
+    )
+    full_state = model.state_dict()
+    apply_fsdp2(
+        model,
+        {"mesh": mesh, "mp_policy": mp, "offload_policy": None, "reshard_after_forward": True},
+        config={},
+    )
+    fsdp2_load_full_state_dict(model, full_state, mesh, None)
+    return model
+
+
+def _load_model(model_path, cp_group):
+    from transformers import Qwen2ForCausalLM
+
+    from verl.models.transformers.monkey_patch import apply_magi_prefix_tree_backend_fsdp
+
+    apply_magi_prefix_tree_backend_fsdp()
+
+    if USE_FSDP:
+        model = _build_fsdp_qwen(model_path)
+    else:
+        model = Qwen2ForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16).cuda()
+    model.train()
+    model.config._attn_implementation = "Magi_Attention"
+    model.config.attention_dropout = 0.0
+
+    n_attached = 0
+    for _, mod in model.named_modules():
+        cls = mod.__class__.__name__.lower()
+        if cls.endswith(("attention", "self_attn", "selfattention")):
+            mod.cp_group = cp_group
+            n_attached += 1
+    print(f"[SANITY] Attached cp_group to {n_attached} attention modules")
+    return model
+
+
+def _build_batch(model):
+    torch.manual_seed(42)
+    vocab = model.config.vocab_size
+    prompt = torch.randint(0, vocab, (P,), device="cuda")
+    samples = []
+    for i in range(N):
+        torch.manual_seed(100 + i)
+        response = torch.randint(0, vocab, (R,), device="cuda")
+        samples.append(torch.cat([prompt, response]))
+    nested = torch.nested.nested_tensor(samples, layout=torch.jagged)
+    return samples, nested
+
+
+def _dyn_forward(model, nested, cp_group):
+    """dynamic-trie + Magi packed forward; returns per-sample logits list."""
+    from verl.models.transformers.monkey_patch import set_magi_attention_key_fsdp
+    from verl.utils.prefix_tree_magi import build_prefix_tree_micro_batch, restore_flat_to_nested
+
+    pt_batch = build_prefix_tree_micro_batch(model, nested, attention_type="magi", cp_size=1, dynamic_trie=True)
+    assert pt_batch is not None
+    set_magi_attention_key_fsdp(model, pt_batch.magi_key)
+    flat_in = pt_batch.local_flat_input_ids.unsqueeze(0)
+    flat_pos = pt_batch.local_flat_position_ids.unsqueeze(0)
+    out = model(input_ids=flat_in, attention_mask=None, position_ids=flat_pos, use_cache=False)
+    flat_logits = out.logits[0][: pt_batch.real_tokens]
+    nested_logits = restore_flat_to_nested(flat_logits, pt_batch)
+    return [nested_logits[i] for i in range(pt_batch.original_batch_size)]
+
+
+def _dense_forward(model, samples):
+    """Per-sample dense (sdpa) forward."""
+    model.config._attn_implementation = "sdpa"
+    try:
+        return [model(input_ids=s.unsqueeze(0), attention_mask=None, use_cache=False).logits[0] for s in samples]
+    finally:
+        model.config._attn_implementation = "Magi_Attention"
+
+
+def _loss(per_sample, samples):
+    """Mean negative log-prob over each sample's response tokens."""
+    losses = []
+    for logits, s in zip(per_sample, samples, strict=False):
+        f = logits.float()
+        labels = s[1:]
+        logp = torch.log_softmax(f[:-1], dim=-1).gather(1, labels.unsqueeze(1)).squeeze(1)
+        losses.append(-logp.mean())
+    return torch.stack(losses).mean()
+
+
+def _grad_norm(model):
+    """Global L2 grad norm. Handles FSDP2 DTensor grads (convert to local, then
+    all-reduce sum-of-squares across ranks)."""
+    total_sq = torch.zeros((), device="cuda")  # scalar (shape ()), not (1,) — avoids DTensor wrap
+    for p in model.parameters():
+        if p.grad is not None:
+            g = p.grad.detach()
+            # FSDP2 wraps p.grad as DTensor; unwrap to local shard before computation.
+            if hasattr(g, "to_local"):
+                g = g.to_local()
+            total_sq = total_sq + g.float().pow(2).sum()
+    if dist.is_initialized() and dist.get_world_size() > 1:
+        dist.all_reduce(total_sq, op=dist.ReduceOp.SUM)
+    return total_sq.sqrt().item()
+
+
+def _max_diff(a, b):
+    return max((x - y).abs().max().item() for x, y in zip(a, b, strict=False))
+
+
+def main() -> int:
+    _init_dist()
+    cp_group = dist.group.WORLD
+
+    model_path = os.environ.get("MODEL_PATH", os.path.expanduser("~/models/Qwen/Qwen2.5-0.5B-Instruct"))
+    print(f"[SANITY] USE_FSDP={USE_FSDP}  N={N} P={P} R={R}")
+    print(f"[SANITY] Loading {model_path}")
+    model = _load_model(model_path, cp_group)
+    samples, nested = _build_batch(model)
+    total_tokens = sum(s.shape[0] for s in samples)
+    print(f"[SANITY] total_tokens={total_tokens}, prefix_shared={P * (N - 1)}")
+
+    BOLD, GREEN, RED, RESET = "\033[1m", "\033[0;32m", "\033[0;31m", "\033[0m"
+    fail = []
+
+    # ──────────────────────────────────────────────────────────────
+    # Check A: forward equivalence (dynamic-trie + Magi vs dense)
+    # ──────────────────────────────────────────────────────────────
+    print()
+    print("[SANITY] Check A: forward equivalence (dynamic-trie + Magi vs dense sdpa)")
+    with torch.no_grad():
+        dyn_logits = _dyn_forward(model, nested, cp_group)
+        dense_logits = _dense_forward(model, samples)
+    fwd_diff = _max_diff(dyn_logits, dense_logits)
+    fwd_threshold = 1.0  # bf16 noise floor at Qwen2.5-0.5B logit scale
+    print(f"[SANITY]   max_diff = {fwd_diff:.4f}  (threshold {fwd_threshold})")
+    if fwd_diff < fwd_threshold:
+        print(f"[SANITY]   {GREEN}check A: PASS{RESET}")
+    else:
+        print(f"[SANITY]   {RED}check A: FAIL{RESET}")
+        fail.append(f"forward max_diff={fwd_diff:.4f}")
+
+    # ──────────────────────────────────────────────────────────────
+    # Check B: backward equivalence (grad_norm rel diff)
+    # ──────────────────────────────────────────────────────────────
+    print()
+    print("[SANITY] Check B: backward grad_norm equivalence")
+    model.zero_grad(set_to_none=True)
+    dyn_logits = _dyn_forward(model, nested, cp_group)
+    _loss(dyn_logits, samples).backward()
+    norm_dyn = _grad_norm(model)
+
+    model.zero_grad(set_to_none=True)
+    dense_logits = _dense_forward(model, samples)
+    _loss(dense_logits, samples).backward()
+    norm_dense = _grad_norm(model)
+
+    rel_diff = abs(norm_dyn - norm_dense) / max(norm_dense, 1e-9)
+    norm_threshold = 0.1  # 10% rel — bf16 + per-sample-vs-packed path diff
+    print(
+        f"[SANITY]   grad_norm dyn={norm_dyn:.4f}  dense={norm_dense:.4f}  "
+        f"rel={rel_diff:.4f}  (threshold {norm_threshold})"
+    )
+    if rel_diff < norm_threshold and torch.isfinite(torch.tensor(norm_dyn)):
+        print(f"[SANITY]   {GREEN}check B: PASS{RESET}")
+    else:
+        print(f"[SANITY]   {RED}check B: FAIL{RESET}")
+        fail.append(f"grad_norm rel={rel_diff:.4f}")
+
+    # ──────────────────────────────────────────────────────────────
+    # Check C: EVAL → TRAIN → EVAL determinism
+    # ──────────────────────────────────────────────────────────────
+    print()
+    print("[SANITY] Check C: EVAL/TRAIN/EVAL mode determinism")
+    model.zero_grad(set_to_none=True)
+
+    model.eval()
+    with torch.no_grad():
+        out_eval_1 = [t.detach().clone() for t in _dyn_forward(model, nested, cp_group)]
+
+    model.train()
+    out_train = [t.detach().clone() for t in _dyn_forward(model, nested, cp_group)]
+
+    model.eval()
+    with torch.no_grad():
+        out_eval_2 = [t.detach().clone() for t in _dyn_forward(model, nested, cp_group)]
+
+    eval_train_diff = _max_diff(out_eval_1, out_train)
+    eval_eval_diff = _max_diff(out_eval_1, out_eval_2)
+    mode_threshold = 1.0  # bf16 noise
+    print(f"[SANITY]   diff(EVAL_1, TRAIN)  = {eval_train_diff:.4f}")
+    print(f"[SANITY]   diff(EVAL_1, EVAL_2) = {eval_eval_diff:.4f}")
+    if eval_train_diff < mode_threshold and eval_eval_diff < mode_threshold:
+        print(f"[SANITY]   {GREEN}check C: PASS{RESET}")
+    else:
+        print(f"[SANITY]   {RED}check C: FAIL{RESET}")
+        fail.append(f"mode diff EVAL/TRAIN={eval_train_diff:.4f}  EVAL/EVAL={eval_eval_diff:.4f}")
+
+    # ──────────────────────────────────────────────────────────────
+    # Verdict
+    # ──────────────────────────────────────────────────────────────
+    print()
+    print("=" * 70)
+    if not fail:
+        print(f"  {GREEN}{BOLD}[SANITY PASS] all 3 checks succeeded ({'FSDP2' if USE_FSDP else 'plain HF'}).{RESET}")
+    else:
+        print(f"  {RED}{BOLD}[SANITY FAIL]{RESET}")
+        for f in fail:
+            print(f"  {RED}  - {f}{RESET}")
+    print("=" * 70)
+    if dist.is_initialized():
+        dist.destroy_process_group()
+    return 0 if not fail else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prefix_script/fsdp/sanity_dynamic_magi_cp.py
+++ b/prefix_script/fsdp/sanity_dynamic_magi_cp.py
@@ -1,0 +1,251 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Sanity test for dynamic-trie + Magi forward under context-parallel (cp_size > 1).
+
+Verifies the module-attribute key-threading fix (commit b6e76b41) on the
+CP dispatch path: cp_size > 1 invokes ``dispatch(...)`` / ``undispatch(...)``
+between build and forward, which also touches the Magi LRU. The fix should
+work regardless of whether the LRU is touched or not — the attention func
+reads the key from ``module._verl_magi_attention_key``, not from the LRU.
+
+What we test
+------------
+1. cp_size=2 dynamic-trie + Magi forward on Qwen2.5-0.5B.
+2. Multi-step LRU pollution to stress the wrong-key risk: build several
+   shapes in a row, then re-forward an earlier shape. Under the old LRU
+   path this would silently use the wrong mgr; under module-attribute
+   threading the output stays correct.
+3. Compare the cp_size=2 packed forward against a single-rank dense
+   (sdpa) baseline. bf16 noise floor ~ a few-tenths in logits.
+
+Usage
+-----
+    torchrun --standalone --nproc_per_node=2 \\
+        prefix_script/fsdp/sanity_dynamic_magi_cp.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+
+def _maybe_init_dist():
+    if not dist.is_initialized():
+        if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+            raise RuntimeError("Run via torchrun so RANK/WORLD_SIZE env vars are set")
+        torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
+        dist.init_process_group(backend="nccl")
+
+
+def _make_nested(samples, device):
+    return torch.nested.nested_tensor(
+        [torch.tensor(s, dtype=torch.long, device=device) for s in samples],
+        layout=torch.jagged,
+    )
+
+
+def _dyn_magi_cp_forward(model, nested, cp_group):
+    """One CP dynamic-trie + Magi forward; returns logits as a flat (total_real_tokens, V) tensor.
+
+    Magi's ``dispatch`` / ``undispatch`` operate on a flat (seq,) tensor along
+    dim=0. Mirror the production pattern: dispatch → unsqueeze for model, then
+    squeeze → undispatch on the way out.
+    """
+    from verl.models.transformers.monkey_patch import set_magi_attention_key_fsdp
+    from verl.utils.prefix_tree_magi import build_prefix_tree_micro_batch, restore_flat_to_nested
+
+    pt_batch = build_prefix_tree_micro_batch(
+        model,
+        nested,
+        attention_type="magi",
+        cp_size=cp_group.size(),
+        dynamic_trie=True,
+    )
+    if pt_batch is None:
+        return None
+
+    if cp_group.size() > 1:
+        from magi_attention.api import dispatch
+
+        local_in = dispatch(pt_batch.local_flat_input_ids, pt_batch.magi_key)
+        local_pos = dispatch(pt_batch.local_flat_position_ids, pt_batch.magi_key)
+    else:
+        local_in = pt_batch.local_flat_input_ids
+        local_pos = pt_batch.local_flat_position_ids
+
+    flat_in = local_in.unsqueeze(0)
+    flat_pos = local_pos.unsqueeze(0)
+
+    set_magi_attention_key_fsdp(model, pt_batch.magi_key)
+    with torch.no_grad():
+        output = model(
+            input_ids=flat_in,
+            attention_mask=None,
+            position_ids=flat_pos,
+            use_cache=False,
+        )
+
+    logits = output.logits.squeeze(0)
+    if cp_group.size() > 1:
+        from magi_attention.api import undispatch
+
+        logits = undispatch(logits, pt_batch.magi_key)
+
+    flat_logits = logits[: pt_batch.real_tokens]
+    nested_logits = restore_flat_to_nested(flat_logits, pt_batch)
+    return [nested_logits[i].detach().clone() for i in range(pt_batch.original_batch_size)]
+
+
+def _dense_forward(model, samples):
+    """Per-sample dense (sdpa) forward; returns list of (L, V) logits."""
+    model.config._attn_implementation = "sdpa"
+    try:
+        with torch.no_grad():
+            out = []
+            for s in samples:
+                inp = torch.tensor([s], dtype=torch.long, device="cuda")
+                logits = model(input_ids=inp, attention_mask=None, use_cache=False).logits[0]
+                out.append(logits)
+        return out
+    finally:
+        model.config._attn_implementation = "Magi_Attention"
+
+
+def main() -> int:
+    _maybe_init_dist()
+
+    from transformers import Qwen2ForCausalLM
+
+    from verl.models.transformers.monkey_patch import apply_magi_prefix_tree_backend_fsdp
+
+    apply_magi_prefix_tree_backend_fsdp()
+
+    model_path = os.environ.get("MODEL_PATH", os.path.expanduser("~/models/Qwen/Qwen2.5-0.5B-Instruct"))
+    if dist.get_rank() == 0:
+        print(f"[CP-SANITY] Loading {model_path}")
+    model = Qwen2ForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16).cuda().eval()
+
+    model.config._attn_implementation = "Magi_Attention"
+    cp_group = dist.group.WORLD
+    cp_size = cp_group.size()
+    if cp_size < 2:
+        if dist.get_rank() == 0:
+            print(f"[CP-SANITY] SKIP: need WORLD_SIZE >= 2 to exercise CP, got {cp_size}")
+        dist.destroy_process_group()
+        return 0
+
+    # Attach cp_group to each attention module — same as
+    # FSDPEngine._attach_magi_cp_group_to_attention_modules.
+    n_attached = 0
+    for _, mod in model.named_modules():
+        cls = mod.__class__.__name__.lower()
+        if cls.endswith(("attention", "self_attn", "selfattention")):
+            mod.cp_group = cp_group
+            n_attached += 1
+    if dist.get_rank() == 0:
+        print(f"[CP-SANITY] cp_size={cp_size}, attached cp_group to {n_attached} attention modules")
+
+    torch.manual_seed(42)
+    P, R, N = 64, 32, 4
+    prompt = torch.randint(0, model.config.vocab_size, (P,), device="cuda")
+    samples = []
+    for i in range(N):
+        torch.manual_seed(100 + i)
+        response = torch.randint(0, model.config.vocab_size, (R,), device="cuda")
+        samples.append(torch.cat([prompt, response]).tolist())
+
+    # ── Step 1: pollute the Magi LRU with a series of different-shape builds.
+    # If the old LRU-side-channel path were still in use, the next REF
+    # forward at the original shape would silently use whatever key was
+    # last inserted, not the one matching its input. With module-attribute
+    # threading, the right key is always set before forward.
+    if dist.get_rank() == 0:
+        print("[CP-SANITY] Polluting LRU with distractor builds ...")
+    nested_main = _make_nested(samples, device="cuda")
+    out_dyn_main = _dyn_magi_cp_forward(model, nested_main, cp_group)
+
+    distractor_lengths = [80, 88, 96, 104, 112]
+    for dl in distractor_lengths:
+        torch.manual_seed(1000 + dl)
+        d_samples = [torch.randint(0, model.config.vocab_size, (dl,), device="cuda").tolist() for _ in range(N)]
+        _dyn_magi_cp_forward(model, _make_nested(d_samples, "cuda"), cp_group)
+
+    if dist.get_rank() == 0:
+        print("[CP-SANITY] Re-running REF after pollution ...")
+    out_dyn_main_again = _dyn_magi_cp_forward(model, nested_main, cp_group)
+
+    # ── Step 2: dense baseline (rank 0 only — sdpa doesn't need CP).
+    if dist.get_rank() == 0:
+        print("[CP-SANITY] Dense (sdpa) baseline ...")
+        out_dense = _dense_forward(model, samples)
+    else:
+        out_dense = None
+
+    # ── Compare on rank 0.
+    if dist.get_rank() == 0:
+        # 1) cp first vs cp re-run after pollution. Bf16 FFA kernel is NOT
+        # deterministic across launches (reduce-order non-determinism),
+        # so we don't require bit-exact — just bf16-noise level.
+        # If module-attribute threading were broken (i.e. we were silently
+        # reusing the wrong cached mgr like repro 7 demonstrates), the
+        # drift would be huge (134%+ in repro 7's FULL-vs-CAUSAL setup).
+        within_max = 0.0
+        for a, b in zip(out_dyn_main, out_dyn_main_again, strict=False):
+            within_max = max(within_max, (a - b).abs().max().item())
+        print(f"[CP-SANITY] cp dynamic-trie first vs re-run after pollution: max_diff={within_max:.6f}")
+
+        # 2) cp dynamic-trie vs dense (sdpa) reference.
+        cp_vs_dense_max = 0.0
+        for a, d in zip(out_dyn_main, out_dense, strict=False):
+            cp_vs_dense_max = max(cp_vs_dense_max, (a - d).abs().max().item())
+        print(f"[CP-SANITY] cp dynamic-trie vs dense (sdpa) baseline:        max_diff={cp_vs_dense_max:.6f}")
+
+        BOLD = "\033[1m"
+        GREEN = "\033[0;32m"
+        RED = "\033[0;31m"
+        RESET = "\033[0m"
+
+        # bf16 noise floor for Qwen2.5-0.5B at logit scale ~10-20 is roughly
+        # one bf16 ULP, i.e. 0.4-0.5. Threshold 1.0 leaves slack but still
+        # catches the LRU-bug magnitude (>>50% drift relative to logit norms).
+        ok_within = within_max < 1.0
+        ok_vs_dense = cp_vs_dense_max < 1.0
+
+        if ok_within and ok_vs_dense:
+            print(
+                f"  {GREEN}{BOLD}[CP-SANITY PASS] cp_size={cp_size} "
+                f"dynamic-trie + Magi correct under LRU pollution{RESET}"
+            )
+            print(f"  {GREEN}                  and matches dense baseline within bf16 noise{RESET}")
+            rc = 0
+        elif not ok_within:
+            print(
+                f"  {RED}{BOLD}[CP-SANITY FAIL] LRU pollution affected output beyond bf16 noise "
+                f"(max_diff={within_max:.4f}){RESET}"
+            )
+            print(f"  {RED}                  module-attribute threading likely broken.{RESET}")
+            rc = 1
+        else:
+            print(
+                f"  {RED}{BOLD}[CP-SANITY FAIL] cp_size={cp_size} dynamic-trie diverges from dense "
+                f"(max_diff={cp_vs_dense_max:.4f}){RESET}"
+            )
+            rc = 2
+    else:
+        rc = 0
+
+    dist.destroy_process_group()
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/utils/test_prefix_tree_dynamic.py
+++ b/tests/utils/test_prefix_tree_dynamic.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the dynamic-trie prefix tree builder.
+
+Exercises :mod:`verl.utils.prefix_tree_dynamic` in isolation (no model / GPU).
+Validates that the token-by-token trie correctly recovers the shared-prefix
+structure across a range of branching factors and tree depths.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from verl.utils.prefix_tree_dynamic import (
+    TrieNode,
+    build_tree_dynamic,
+    convert_trie_to_tree_node,
+    greedy_build_tries,
+)
+from verl.utils.prefix_tree_utils import TreeNode, build_layout_from_tree_node
+
+# ---------------------------------------------------------------------------
+# Lower-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_leaf_segments(node: TreeNode) -> list[int]:
+    """Return segment lengths of leaves in DFS pre-order."""
+    if node.is_leaf:
+        return [node.segment_len]
+    out: list[int] = []
+    for child in node.children:
+        out.extend(_collect_leaf_segments(child))
+    return out
+
+
+def _count_leaves(node: TreeNode) -> int:
+    if node.is_leaf:
+        return 1
+    return sum(_count_leaves(c) for c in node.children)
+
+
+# ---------------------------------------------------------------------------
+# greedy_build_tries
+# ---------------------------------------------------------------------------
+
+
+def test_greedy_build_tries_single_forest_for_shared_prefix():
+    """Sequences sharing the first token end up in one trie (one forest)."""
+    sequences = [
+        [1, 2, 3, 4],
+        [1, 2, 3, 5],
+        [1, 2, 6, 7],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    assert len(tries) == 1
+    assert isinstance(tries[0], TrieNode)
+    assert tries[0].is_root
+
+
+def test_greedy_build_tries_separate_forest_for_no_shared_prefix():
+    """Sequences with different first token still pack into one forest under
+    a generous ``max_tokens_per_tree`` — they share the virtual root."""
+    sequences = [
+        [1, 2, 3],
+        [4, 5, 6],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    # Both sequences inserted into the same forest (the virtual root has 2 child branches).
+    assert len(tries) == 1
+    assert len(tries[0].children) == 2
+
+
+# ---------------------------------------------------------------------------
+# convert_trie_to_tree_node
+# ---------------------------------------------------------------------------
+
+
+def test_convert_trie_to_tree_node_depth_2():
+    """Simple depth-2 case: 3 sequences sharing 2-token prefix, then diverging
+    into 3 distinct branches of length 2."""
+    sequences = [
+        [10, 11, 20, 21],
+        [10, 11, 30, 31],
+        [10, 11, 40, 41],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    result = convert_trie_to_tree_node(tries[0])
+    assert result is not None
+    tree_root, leaf_to_sample = result
+
+    # Root segment_len == 2 (the shared [10, 11])
+    assert tree_root.segment_len == 2
+    # 3 leaf children, each of segment_len 2 ([20,21] / [30,31] / [40,41])
+    assert len(tree_root.children) == 3
+    leaf_segs = _collect_leaf_segments(tree_root)
+    assert leaf_segs == [2, 2, 2]
+    # leaf_to_sample is the original sample order (sorted by first divergent token)
+    assert sorted(leaf_to_sample) == [0, 1, 2]
+
+
+def test_convert_trie_to_tree_node_depth_3_multilevel():
+    """Depth-3 multi-level: 4 sequences forming a balanced 2x2 tree.
+
+    Tree shape:
+        root [10, 11]
+            ├── [20, 21]
+            │       ├── [30, 31]   <- sample 0
+            │       └── [40, 41]   <- sample 1
+            └── [50, 51]
+                    ├── [60, 61]   <- sample 2
+                    └── [70, 71]   <- sample 3
+    """
+    sequences = [
+        [10, 11, 20, 21, 30, 31],
+        [10, 11, 20, 21, 40, 41],
+        [10, 11, 50, 51, 60, 61],
+        [10, 11, 50, 51, 70, 71],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    result = convert_trie_to_tree_node(tries[0])
+    assert result is not None
+    tree_root, leaf_to_sample = result
+
+    # Root has shared 2-token prefix [10, 11], 2 internal children
+    assert tree_root.segment_len == 2
+    assert len(tree_root.children) == 2
+    # 4 leaves total
+    assert _count_leaves(tree_root) == 4
+    # Each leaf is segment_len=2 ([30,31] / [40,41] / [60,61] / [70,71])
+    assert _collect_leaf_segments(tree_root) == [2, 2, 2, 2]
+    assert sorted(leaf_to_sample) == [0, 1, 2, 3]
+
+
+def test_convert_trie_returns_none_for_single_sample():
+    """A single sample has no shared structure → returns None."""
+    sequences = [[1, 2, 3, 4]]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    result = convert_trie_to_tree_node(tries[0])
+    assert result is None
+
+
+def test_convert_trie_returns_none_for_multi_forest():
+    """When the virtual root has multiple children (no shared first token),
+    return None."""
+    sequences = [
+        [1, 2, 3],
+        [4, 5, 6],
+    ]
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=1000)
+    result = convert_trie_to_tree_node(tries[0])
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# build_tree_dynamic (the public entry consumed by build_prefix_tree_micro_batch)
+# ---------------------------------------------------------------------------
+
+
+def test_build_tree_dynamic_recovers_depth_2():
+    samples = [
+        torch.tensor([10, 11, 20, 21], dtype=torch.long),
+        torch.tensor([10, 11, 30, 31], dtype=torch.long),
+        torch.tensor([10, 11, 40, 41], dtype=torch.long),
+    ]
+    result = build_tree_dynamic(samples)
+    assert result is not None
+    tree_root, leaf_to_sample = result
+    assert tree_root.segment_len == 2
+    assert _count_leaves(tree_root) == 3
+    assert sorted(leaf_to_sample) == [0, 1, 2]
+
+
+def test_build_tree_dynamic_recovers_depth_3():
+    samples = [
+        torch.tensor([10, 11, 20, 21, 30], dtype=torch.long),
+        torch.tensor([10, 11, 20, 21, 40], dtype=torch.long),
+        torch.tensor([10, 11, 50, 51, 60], dtype=torch.long),
+    ]
+    result = build_tree_dynamic(samples)
+    assert result is not None
+    tree_root, _ = result
+    # Root [10, 11], internal child [20, 21] with 2 leaves + [50, 51] with 1 leaf
+    assert tree_root.segment_len == 2
+    assert _count_leaves(tree_root) == 3
+    # Total internal+leaf nodes > 4 → confirms multi-level
+    leaf_segs = _collect_leaf_segments(tree_root)
+    assert sum(leaf_segs) <= sum(len(s) for s in samples)  # sanity
+
+
+def test_build_tree_dynamic_returns_none_for_disjoint():
+    samples = [
+        torch.tensor([1, 2, 3], dtype=torch.long),
+        torch.tensor([4, 5, 6], dtype=torch.long),
+    ]
+    assert build_tree_dynamic(samples) is None
+
+
+def test_build_tree_dynamic_returns_none_for_empty():
+    assert build_tree_dynamic([]) is None
+
+
+def test_build_tree_dynamic_returns_none_for_single_sample():
+    samples = [torch.tensor([1, 2, 3], dtype=torch.long)]
+    assert build_tree_dynamic(samples) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: build_tree_dynamic → build_layout_from_tree_node
+# ---------------------------------------------------------------------------
+
+
+def test_layout_from_dynamic_tree_token_conservation():
+    """Flat layout produced from a dynamic tree must contain each unique node's
+    tokens exactly once. For a depth-2 tree with 3 samples sharing 2-prefix,
+    total flat tokens == 2 (root) + 3*2 (leaves) = 8.
+    """
+    samples = [
+        torch.tensor([10, 11, 20, 21], dtype=torch.long),
+        torch.tensor([10, 11, 30, 31], dtype=torch.long),
+        torch.tensor([10, 11, 40, 41], dtype=torch.long),
+    ]
+    result = build_tree_dynamic(samples)
+    assert result is not None
+    tree_root, leaf_to_sample = result
+
+    params = build_layout_from_tree_node(samples, tree_root, leaf_to_sample)
+    assert params.flat_tokens.shape[0] == 2 + 3 * 2  # 8
+    assert params.multilevel is True
+    assert len(params.leaf_to_sample) == 3
+    # Root range covers the first 2 tokens
+    assert params.prefix_range == (0, 2)
+    # 3 leaf ranges, each of length 2
+    assert len(params.leaf_ranges) == 3
+    for s, e in params.leaf_ranges:
+        assert e - s == 2
+
+
+def test_layout_from_dynamic_tree_depth_3_token_conservation():
+    """Depth-3 tree: 4 samples × 6 tokens = 24 baseline.
+    Tree shares: root[2] + 2 internal[2 each] + 4 leaves[2 each] = 14 flat tokens.
+    """
+    samples = [
+        torch.tensor([10, 11, 20, 21, 30, 31], dtype=torch.long),
+        torch.tensor([10, 11, 20, 21, 40, 41], dtype=torch.long),
+        torch.tensor([10, 11, 50, 51, 60, 61], dtype=torch.long),
+        torch.tensor([10, 11, 50, 51, 70, 71], dtype=torch.long),
+    ]
+    result = build_tree_dynamic(samples)
+    assert result is not None
+    tree_root, leaf_to_sample = result
+
+    params = build_layout_from_tree_node(samples, tree_root, leaf_to_sample)
+    # 2 (root) + 2*2 (internal) + 4*2 (leaves) = 14
+    assert params.flat_tokens.shape[0] == 14
+    assert len(params.leaf_ranges) == 4
+    # Check that flat_tokens are correct: every original sample's tokens are present
+    flat = params.flat_tokens.tolist()
+    assert 10 in flat and 11 in flat  # root
+    assert 20 in flat and 21 in flat  # internal A
+    assert 50 in flat and 51 in flat  # internal B
+    assert 30 in flat and 31 in flat  # leaf A1
+    assert 70 in flat and 71 in flat  # leaf B2

--- a/tests/utils/test_prefix_tree_magi.py
+++ b/tests/utils/test_prefix_tree_magi.py
@@ -17,15 +17,15 @@ These tests exercise build_prefix_tree_micro_batch (without the MAGI key
 construction, which requires GPU + distributed) and restore_flat_to_nested.
 All prefix-tree utilities now live in verl.utils — no Megatron-LM fork needed.
 """
+
 from __future__ import annotations
 
-import pytest
 import torch
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_nested(token_lists: list[list[int]], device="cpu") -> torch.Tensor:
     """Build a jagged NestedTensor from a list of token ID lists."""
@@ -41,6 +41,7 @@ def _make_nested_float(value_lists: list[list[float]], device="cpu") -> torch.Te
 # ---------------------------------------------------------------------------
 # Tests for the core layout helpers (no MAGI key, no model)
 # ---------------------------------------------------------------------------
+
 
 class TestBuildPrefixTreeLayout:
     """Tests that verify the flat layout and PrefixTreeParams fields.
@@ -107,12 +108,12 @@ class TestBuildPrefixTreeLayout:
         # (3,5)→(3,5) causal  — leaf_0 self
         # (5,6)→(0,3) full    — leaf_1 attends to prefix
         # (5,6)→(5,6) causal  — leaf_1 self
-        rects = set(zip(params.q_ranges, params.k_ranges, params.mask_types))
-        assert ((0, 3), (0, 3), 'causal') in rects
-        assert ((3, 5), (0, 3), 'full') in rects
-        assert ((3, 5), (3, 5), 'causal') in rects
-        assert ((5, 6), (0, 3), 'full') in rects
-        assert ((5, 6), (5, 6), 'causal') in rects
+        rects = set(zip(params.q_ranges, params.k_ranges, params.mask_types, strict=False))
+        assert ((0, 3), (0, 3), "causal") in rects
+        assert ((3, 5), (0, 3), "full") in rects
+        assert ((3, 5), (3, 5), "causal") in rects
+        assert ((5, 6), (0, 3), "full") in rects
+        assert ((5, 6), (5, 6), "causal") in rects
         assert len(rects) == 5
 
 
@@ -120,13 +121,14 @@ class TestBuildPrefixTreeLayout:
 # Tests for restore_flat_to_nested
 # ---------------------------------------------------------------------------
 
+
 class TestRestoreFlatToNested:
     """Tests that verify round-trip: build params → restore → original tensors."""
 
     def _build_pt_batch(self, tokens, prefix_len):
         """Build a PrefixTreeMagiBatch stub without the MAGI key."""
-        from verl.utils.prefix_tree_utils import build_prefix_tree_params
         from verl.utils.prefix_tree_magi import PrefixTreeMagiBatch
+        from verl.utils.prefix_tree_utils import build_prefix_tree_params
 
         params = build_prefix_tree_params(tokens, prefix_len=prefix_len)
         return PrefixTreeMagiBatch(
@@ -209,14 +211,14 @@ class TestRestoreFlatToNested:
 
     def test_custom_sample_indices(self):
         """sample_indices remapping: leaf_to_sample=[1,0] → restored in index order."""
-        from verl.utils.prefix_tree_utils import build_prefix_tree_params
         from verl.utils.prefix_tree_magi import PrefixTreeMagiBatch, restore_flat_to_nested
+        from verl.utils.prefix_tree_utils import build_prefix_tree_params
 
         # sample_indices=[1,0] means the first token list maps to sample 1,
         # and the second maps to sample 0.
         tokens = [
             torch.tensor([10, 20, 30, 41, 42]),  # → sample 1
-            torch.tensor([10, 20, 30, 51]),       # → sample 0
+            torch.tensor([10, 20, 30, 51]),  # → sample 0
         ]
         params = build_prefix_tree_params(tokens, prefix_len=3, sample_indices=[1, 0])
         pt_batch = PrefixTreeMagiBatch(
@@ -249,6 +251,7 @@ class TestRestoreFlatToNested:
 # ---------------------------------------------------------------------------
 # Integration: NestedTensor input → flat layout (no MAGI key)
 # ---------------------------------------------------------------------------
+
 
 class TestNestedTensorUnpack:
     """Tests that build_prefix_tree_micro_batch correctly unpacks NestedTensors."""
@@ -291,6 +294,7 @@ class TestNestedTensorUnpack:
 
     def test_no_shared_prefix_returns_none(self, monkeypatch):
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         class FakeModel:
@@ -299,6 +303,7 @@ class TestNestedTensorUnpack:
                 num_query_groups = 8
                 kv_channels = 128
                 fp8 = None
+
             pre_process = True
             post_process = True
 
@@ -311,6 +316,7 @@ class TestNestedTensorUnpack:
     def test_loss_mask_flattened(self, monkeypatch):
         """loss_mask NestedTensor is correctly flattened into flat_loss_mask."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         class FakeModel:
@@ -319,6 +325,7 @@ class TestNestedTensorUnpack:
                 num_query_groups = 8
                 kv_channels = 128
                 fp8 = None
+
             pre_process = True
             post_process = True
 
@@ -343,12 +350,14 @@ class TestNestedTensorUnpack:
 # Tests for prefix_segments prior-knowledge path
 # ---------------------------------------------------------------------------
 
+
 class TestPrefixSegmentsPrior:
     """Tests for the fast hash-based prefix detection path."""
 
     def _make_segments(self, token_lists: list[list[int]]) -> list[list[tuple[int, int]]]:
         """Build ground-truth prefix_segments for a list of token sequences."""
         from verl.utils.prefix_tree_magi import _hash_prefix
+
         result = []
         for tokens in token_lists:
             segs = []
@@ -365,13 +374,16 @@ class TestPrefixSegmentsPrior:
                 num_query_groups = 8
                 kv_channels = 128
                 fp8 = None
+
             pre_process = True
             post_process = True
+
         return FakeModel()
 
     def test_prior_matches_scan(self, monkeypatch):
         """Prior-knowledge path returns same prefix_len as the token-scan path."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         token_lists = [[10, 20, 30, 41, 42], [10, 20, 30, 51]]
@@ -380,12 +392,8 @@ class TestPrefixSegmentsPrior:
         # Build segments that exactly match turn boundaries at every token.
         segs = self._make_segments(token_lists)
 
-        result_prior = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids, prefix_segments_batch=segs
-        )
-        result_scan = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids
-        )
+        result_prior = ptm.build_prefix_tree_micro_batch(self._fake_model(), input_ids, prefix_segments_batch=segs)
+        result_scan = ptm.build_prefix_tree_micro_batch(self._fake_model(), input_ids)
 
         assert result_prior is not None
         assert result_scan is not None
@@ -395,6 +403,7 @@ class TestPrefixSegmentsPrior:
     def test_prior_uses_coarsest_shared_boundary(self, monkeypatch):
         """Prior with turn-level segments finds the longest sub-turn boundary."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         from verl.utils.prefix_tree_magi import _hash_prefix
@@ -409,7 +418,8 @@ class TestPrefixSegmentsPrior:
 
         input_ids = _make_nested([[10, 20, 30, 41, 42], [10, 20, 30, 51]])
         result = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids,
+            self._fake_model(),
+            input_ids,
             prefix_segments_batch=[segs0, segs1],
         )
         assert result is not None
@@ -419,20 +429,20 @@ class TestPrefixSegmentsPrior:
     def test_prior_fallback_on_missing(self, monkeypatch):
         """When prefix_segments_batch is None, the scan path is used."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         token_lists = [[10, 20, 30, 41, 42], [10, 20, 30, 51]]
         input_ids = _make_nested(token_lists)
 
-        result = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids, prefix_segments_batch=None
-        )
+        result = ptm.build_prefix_tree_micro_batch(self._fake_model(), input_ids, prefix_segments_batch=None)
         assert result is not None
         assert result.prefix_range == (0, 3)
 
     def test_prior_no_shared_entry_returns_none(self, monkeypatch):
         """When no hash is shared across all samples, returns None (no prefix)."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
         from verl.utils.prefix_tree_magi import _hash_prefix
@@ -444,7 +454,8 @@ class TestPrefixSegmentsPrior:
 
         input_ids = _make_nested([[1, 2, 3], [4, 5, 6]])
         result = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids,
+            self._fake_model(),
+            input_ids,
             prefix_segments_batch=[segs0, segs1],
         )
         assert result is None
@@ -452,14 +463,13 @@ class TestPrefixSegmentsPrior:
     def test_prior_after_shuffle(self, monkeypatch):
         """Hash lookup still finds the correct prefix after index reordering."""
         import verl.utils.prefix_tree_magi as ptm
+
         monkeypatch.setattr(ptm, "_build_magi_key", lambda model, params: object())
 
-        from verl.utils.prefix_tree_magi import _hash_prefix
-
         token_lists = [
-            [10, 20, 30, 41],   # sample 0
-            [10, 20, 30, 51],   # sample 1
-            [10, 20, 30, 61],   # sample 2
+            [10, 20, 30, 41],  # sample 0
+            [10, 20, 30, 51],  # sample 1
+            [10, 20, 30, 61],  # sample 2
         ]
         segs = self._make_segments(token_lists)
 
@@ -469,7 +479,8 @@ class TestPrefixSegmentsPrior:
         input_ids = _make_nested(shuffled_tokens)
 
         result = ptm.build_prefix_tree_micro_batch(
-            self._fake_model(), input_ids,
+            self._fake_model(),
+            input_ids,
             prefix_segments_batch=shuffled_segs,
         )
         assert result is not None
@@ -477,7 +488,7 @@ class TestPrefixSegmentsPrior:
 
     def test_build_prefix_segments_single_turn(self):
         """build_prefix_segments_single_turn produces a one-entry list."""
-        from verl.utils.prefix_tree_magi import build_prefix_segments_single_turn, _hash_prefix
+        from verl.utils.prefix_tree_magi import _hash_prefix, build_prefix_segments_single_turn
 
         ids = torch.tensor([1, 2, 3, 4, 5], dtype=torch.long)
         segs = build_prefix_segments_single_turn(ids)
@@ -488,7 +499,7 @@ class TestPrefixSegmentsPrior:
 
     def test_build_prefix_segments_single_turn_with_mask(self):
         """Padding tokens are excluded when attention_mask is provided."""
-        from verl.utils.prefix_tree_magi import build_prefix_segments_single_turn, _hash_prefix
+        from verl.utils.prefix_tree_magi import _hash_prefix, build_prefix_segments_single_turn
 
         ids = torch.tensor([1, 2, 3, 0, 0], dtype=torch.long)
         mask = torch.tensor([1, 1, 1, 0, 0], dtype=torch.long)

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -410,8 +410,9 @@ class AgentLoopWorker:
             )
 
         # Load tools once per worker; each trajectory just reuses self.tools.
+        # function_tool_path may be absent on older rollout schemas.
         tool_config_path = self.rollout_config.multi_turn.tool_config_path
-        function_tool_path = self.rollout_config.multi_turn.function_tool_path
+        function_tool_path = getattr(self.rollout_config.multi_turn, "function_tool_path", None)
         self.tools = load_all_tools(
             tool_config_path=resolve_config_path(tool_config_path) if tool_config_path else None,
             function_tool_path=resolve_config_path(function_tool_path) if function_tool_path else None,

--- a/verl/models/mcore/magi_patch.py
+++ b/verl/models/mcore/magi_patch.py
@@ -1,9 +1,23 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Backward-compatibility shim — use prefix_tree_merge instead."""
+
 from verl.models.mcore.prefix_tree_merge import (  # noqa: F401
-    apply_prefix_tree_patch,
-    apply_magi_patch,
-    _magi_attn_forward,
     _flex_attn_forward,
     _layer_capture,
     _layer_counter,
+    _magi_attn_forward,
+    apply_magi_patch,
+    apply_prefix_tree_patch,
 )

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -254,6 +254,7 @@ def gptmodel_forward_model_engine(
         # ------------------------------------------------------------------
         use_prefix_tree = (logits_processor_args or {}).get("use_prefix_tree", False)
         prefix_tree_attention = (logits_processor_args or {}).get("prefix_tree_attention", "flex")
+        prefix_tree_dynamic = (logits_processor_args or {}).get("prefix_tree_dynamic", False)
         pt_batch = None
         if use_prefix_tree and not vision_model and not mtp_enable_train:
             from verl.utils.prefix_tree_magi import (
@@ -283,6 +284,7 @@ def gptmodel_forward_model_engine(
                 attention_type=prefix_tree_attention,
                 tp_size=_mpu.get_tensor_model_parallel_world_size(),
                 cp_size=_mpu.get_context_parallel_world_size(),
+                dynamic_trie=prefix_tree_dynamic,
             )
             _t1 = _time.perf_counter()
             if pt_batch is not None:

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -18,6 +18,7 @@ from typing import Optional
 import torch
 from torch.nested._internal.nested_tensor import NestedTensor
 
+from verl.utils.device import get_torch_device
 from verl.utils.megatron_utils import unwrap_model
 from verl.workers.config import MtpConfig
 
@@ -210,8 +211,6 @@ def _convert_to_nested_tensor(v, input_ids_lengths):
     return v
 
 
-
-
 def gptmodel_forward_model_engine(
     model,
     input_ids,
@@ -246,6 +245,7 @@ def gptmodel_forward_model_engine(
 
     batch_size = input_ids.shape[0]
     import time as _time
+
     import torch.distributed as _dist
 
     if data_format == "thd":
@@ -257,27 +257,28 @@ def gptmodel_forward_model_engine(
         pt_batch = None
         if use_prefix_tree and not vision_model and not mtp_enable_train:
             from verl.utils.prefix_tree_magi import (
-                PrefixTreeMagiBatch,
                 build_prefix_tree_micro_batch,
                 restore_flat_to_nested,
             )
+
             loss_mask_nested = (logits_processor_args or {}).get("loss_mask", None)
             prefix_segments_batch = (logits_processor_args or {}).get("prefix_segments_batch", None)
             # prefix_segments_batch may be a numpy object array or NonTensorStack; convert to list of lists.
             if prefix_segments_batch is not None:
                 import numpy as _np
+
                 if isinstance(prefix_segments_batch, _np.ndarray):
                     prefix_segments_batch = prefix_segments_batch.tolist()
-                elif hasattr(prefix_segments_batch, '__iter__') and not isinstance(prefix_segments_batch, list):
+                elif hasattr(prefix_segments_batch, "__iter__") and not isinstance(prefix_segments_batch, list):
                     # NonTensorStack from SFTTensorCollator: each element is NonTensorData with .data
-                    prefix_segments_batch = [
-                        el.data if hasattr(el, 'data') else el
-                        for el in prefix_segments_batch
-                    ]
+                    prefix_segments_batch = [el.data if hasattr(el, "data") else el for el in prefix_segments_batch]
             from megatron.core import parallel_state as _mpu
+
             _t0 = _time.perf_counter()
             pt_batch = build_prefix_tree_micro_batch(
-                model, input_ids, loss_mask_nested,
+                model,
+                input_ids,
+                loss_mask_nested,
                 prefix_segments_batch=prefix_segments_batch,
                 attention_type=prefix_tree_attention,
                 tp_size=_mpu.get_tensor_model_parallel_world_size(),
@@ -289,32 +290,36 @@ def gptmodel_forward_model_engine(
                 _flat_tokens = pt_batch.real_tokens
                 _share_ratio = (_full_tokens - _flat_tokens) / _full_tokens if _full_tokens > 0 else 0.0
                 if not _dist.is_initialized() or _dist.get_rank() == 0:
-                    print(f"[PT-TIME] build_micro_batch={(_t1-_t0)*1000:.2f}ms "
-                          f"total_tokens={pt_batch.flat_input_ids.shape[0]} "
-                          f"real_tokens={_flat_tokens} "
-                          f"full_tokens={_full_tokens} "
-                          f"prefix_sharing={_share_ratio:.1%} "
-                          f"attn={prefix_tree_attention}", flush=True)
+                    print(
+                        f"[PT-TIME] build_micro_batch={(_t1 - _t0) * 1000:.2f}ms "
+                        f"total_tokens={pt_batch.flat_input_ids.shape[0]} "
+                        f"real_tokens={_flat_tokens} "
+                        f"full_tokens={_full_tokens} "
+                        f"prefix_sharing={_share_ratio:.1%} "
+                        f"attn={prefix_tree_attention}",
+                        flush=True,
+                    )
             if pt_batch is None:
                 if not _dist.is_initialized() or _dist.get_rank() == 0:
                     # Diagnose why prefix-tree returned None
-                    _bs = input_ids.shape[0] if hasattr(input_ids, 'shape') else len(input_ids)
+                    _bs = input_ids.shape[0] if hasattr(input_ids, "shape") else len(input_ids)
                     _segs = prefix_segments_batch[:2] if prefix_segments_batch is not None else None
                 use_prefix_tree = False  # no shared prefix — fall through
 
         # MEM_DUMP: start recording before forward if requested
         import os as _os
-        _mem_tag = _os.environ.get('MEM_DUMP_TAG', '')
-        _mem_dir = _os.environ.get('MEM_DUMP_DIR', '/tmp/claude')
+
+        _mem_tag = _os.environ.get("MEM_DUMP_TAG", "")
+        _mem_dir = _os.environ.get("MEM_DUMP_DIR", "/tmp/claude")
         _mem_rank0 = True  # only rank 0
         try:
             import torch.distributed as _dist
+
             _mem_rank0 = not _dist.is_initialized() or _dist.get_rank() == 0
         except Exception:
             pass
         if _mem_tag and _mem_rank0:
-            import torch as _t
-            _t.cuda.memory._record_memory_history(max_entries=50_000)
+            get_torch_device().memory._record_memory_history(max_entries=50_000)
 
         if use_prefix_tree and pt_batch is not None:
             # Flat token layout — pass full flat tokens to model.
@@ -332,9 +337,9 @@ def gptmodel_forward_model_engine(
                     logits_processor_args.pop(_k)
 
             _tf0 = _time.perf_counter()
-            torch.cuda.synchronize()
-            torch.cuda.reset_peak_memory_stats()
-            _mem_before = torch.cuda.memory_allocated() / 1024**2
+            get_torch_device().synchronize()
+            get_torch_device().reset_peak_memory_stats()
+            _mem_before = get_torch_device().memory_allocated() / 1024**2
             if prefix_tree_attention == "magi":
                 output_orig = model(
                     input_ids=flat_input_ids,
@@ -353,43 +358,52 @@ def gptmodel_forward_model_engine(
                     flex_attention_key=pt_batch.flex_key,
                     **model_kwargs,
                 )
-            torch.cuda.synchronize()
+            get_torch_device().synchronize()
             _tf1 = _time.perf_counter()
             if not _dist.is_initialized() or _dist.get_rank() == 0:
-                _peak_mb = torch.cuda.max_memory_allocated() / 1024**2
-                _alloc_mb = torch.cuda.memory_allocated() / 1024**2
-                print(f"[PT-TIME] model_fwd={(_tf1-_tf0)*1000:.2f}ms peak_mem={_peak_mb:.0f}MB prefix_sharing={_share_ratio:.1%} attn={prefix_tree_attention}", flush=True)
+                _peak_mb = get_torch_device().max_memory_allocated() / 1024**2
+                _alloc_mb = get_torch_device().memory_allocated() / 1024**2
+                print(
+                    f"[PT-TIME] model_fwd={(_tf1 - _tf0) * 1000:.2f}ms "
+                    f"peak_mem={_peak_mb:.0f}MB prefix_sharing={_share_ratio:.1%} "
+                    f"attn={prefix_tree_attention}",
+                    flush=True,
+                )
 
             if post_process and logits_processor is not None:
                 # Strip TP padding (added for sequence-parallel divisibility).
                 real_tokens = pt_batch.real_tokens
                 if output_orig.shape[0] == 1:
-                    output_orig = output_orig[:, :real_tokens]       # (1, real_tokens, vocab)
+                    output_orig = output_orig[:, :real_tokens]  # (1, real_tokens, vocab)
                 else:
                     output_orig = output_orig[:real_tokens].permute(1, 0, 2)  # (1, real_tokens, vocab)
-
 
                 # Transpose to THD: vocab_parallel_cross_entropy expects (total_tokens, batch, vocab)
                 output_orig_thd = output_orig.squeeze(0).unsqueeze(1)  # (real_tokens, 1, vocab)
 
-                import os as _os2, torch.distributed as _dist2
-                _save_cp2 = _os2.environ.get('SAVE_CP_TENSORS') == '1'
-                _cp_rank2 = _dist2.get_rank() if _dist2.is_initialized() else 0
-                _save_dir2 = _os2.environ.get('CP_TENSOR_DIR', '/tmp/claude/cp_tensors')
-                def _save2(name, tensor):
-                    if not _save_cp2: return
-                    _os2.makedirs(_save_dir2, exist_ok=True)
-                    path = f'{_save_dir2}/{name}_rank{_cp_rank2}.pt'
-                    torch.save(tensor.detach().cpu(), path)
-                    print(f'[CP_SAVE] {name} shape={tuple(tensor.shape)} rank={_cp_rank2} → {path}', flush=True)
+                import os as _os2
 
-                _save2('model_forward_output_logits', output_orig_thd)
+                import torch.distributed as _dist2
+
+                _save_cp2 = _os2.environ.get("SAVE_CP_TENSORS") == "1"
+                _cp_rank2 = _dist2.get_rank() if _dist2.is_initialized() else 0
+                _save_dir2 = _os2.environ.get("CP_TENSOR_DIR", "/tmp/claude/cp_tensors")
+
+                def _save2(name, tensor):
+                    if not _save_cp2:
+                        return
+                    _os2.makedirs(_save_dir2, exist_ok=True)
+                    path = f"{_save_dir2}/{name}_rank{_cp_rank2}.pt"
+                    torch.save(tensor.detach().cpu(), path)
+                    print(f"[CP_SAVE] {name} shape={tuple(tensor.shape)} rank={_cp_rank2} → {path}", flush=True)
+
+                _save2("model_forward_output_logits", output_orig_thd)
 
                 # Shift labels by -1 for next-token prediction (same as preprocess_thd_engine)
-                flat_label = torch.roll(
-                    pt_batch.flat_input_ids[:real_tokens], shifts=-1, dims=0
-                ).unsqueeze(1)  # (real_tokens, 1)
-                _save2('model_forward_flat_label', flat_label.squeeze(1))
+                flat_label = torch.roll(pt_batch.flat_input_ids[:real_tokens], shifts=-1, dims=0).unsqueeze(
+                    1
+                )  # (real_tokens, 1)
+                _save2("model_forward_flat_label", flat_label.squeeze(1))
                 orig_args = logits_processor_args or {}
                 total_tokens = flat_label.shape[0]
                 # temperature in THD: (total_tokens, 1)
@@ -401,14 +415,14 @@ def gptmodel_forward_model_engine(
                         scalar_t = t.flatten()[0].item()
                     else:
                         scalar_t = float(t)
-                    flat_t = torch.full((total_tokens, 1), scalar_t,
-                                        dtype=torch.float32, device=flat_label.device)
+                    flat_t = torch.full((total_tokens, 1), scalar_t, dtype=torch.float32, device=flat_label.device)
                 else:
-                    flat_t = torch.ones(total_tokens, 1,
-                                        dtype=torch.float32, device=flat_label.device)
-                flat_args = {k: v for k, v in orig_args.items()
-                             if k not in ("label", "temperature", "loss_mask",
-                                          "use_prefix_tree", "prefix_segments_batch")}
+                    flat_t = torch.ones(total_tokens, 1, dtype=torch.float32, device=flat_label.device)
+                flat_args = {
+                    k: v
+                    for k, v in orig_args.items()
+                    if k not in ("label", "temperature", "loss_mask", "use_prefix_tree", "prefix_segments_batch")
+                }
                 flat_args["label"] = flat_label
                 flat_args["temperature"] = flat_t
                 output_dict = logits_processor(output_orig_thd, **flat_args)
@@ -417,18 +431,21 @@ def gptmodel_forward_model_engine(
                 if isinstance(output_dict, dict) and "log_probs" in output_dict:
                     # log_probs shape: (1, T) — batch-first from vocab_parallel_log_probs_from_logits
                     lp_flat = output_dict["log_probs"].reshape(-1)[:real_tokens]  # (real_tokens,)
-                    _save2('before_restore_log_probs_flat', lp_flat)
+                    _save2("before_restore_log_probs_flat", lp_flat)
                     output_dict["log_probs"] = restore_flat_to_nested(lp_flat, pt_batch)
                     # save per-sample log_probs after restore
                     _nested = output_dict["log_probs"]
-                    if hasattr(_nested, 'values'):
-                        _save2('after_restore_log_probs_flat', _nested.values())
+                    if hasattr(_nested, "values"):
+                        _save2("after_restore_log_probs_flat", _nested.values())
                 output = output_dict
             else:
                 # Strip TP padding before restoring
                 real_tokens = pt_batch.real_tokens
-                out_stripped = output_orig[:, :real_tokens].squeeze(0) \
-                    if output_orig.shape[0] == 1 else output_orig[:real_tokens].squeeze(1)
+                out_stripped = (
+                    output_orig[:, :real_tokens].squeeze(0)
+                    if output_orig.shape[0] == 1
+                    else output_orig[:real_tokens].squeeze(1)
+                )
                 output = restore_flat_to_nested(out_stripped, pt_batch)
 
         else:
@@ -474,19 +491,21 @@ def gptmodel_forward_model_engine(
                 input_ids_rmpad, attention_mask = build_vlm_attn_mask_thd(input_ids, pad_token_id)
 
             _tfa0 = _time.perf_counter()
-            torch.cuda.synchronize()
+            get_torch_device().synchronize()
             output_orig = model(
                 input_ids=input_ids_rmpad,
                 attention_mask=attention_mask,
-                position_ids=position_ids_rmpad if not vision_model else None,  # vision models will calculate position_ids
+                position_ids=position_ids_rmpad
+                if not vision_model
+                else None,  # vision models will calculate position_ids
                 packed_seq_params=packed_seq_params,
                 **model_kwargs,
             )
-            torch.cuda.synchronize()
+            get_torch_device().synchronize()
             _tfa1 = _time.perf_counter()
             if not _dist.is_initialized() or _dist.get_rank() == 0:
-                _peak_mb = torch.cuda.max_memory_allocated() / 1024**2
-                print(f"[FA3-TIME] model_fwd={(_tfa1-_tfa0)*1000:.2f}ms peak_mem={_peak_mb:.0f}MB", flush=True)
+                _peak_mb = get_torch_device().max_memory_allocated() / 1024**2
+                print(f"[FA3-TIME] model_fwd={(_tfa1 - _tfa0) * 1000:.2f}ms peak_mem={_peak_mb:.0f}MB", flush=True)
 
             if post_process and logits_processor is not None:
                 args = {
@@ -499,36 +518,51 @@ def gptmodel_forward_model_engine(
                     )[0]
                     for k, v in logits_processor_args.items()
                 }
-                import os as _os3, torch.distributed as _dist3
-                _save_cp3 = _os3.environ.get('SAVE_CP_TENSORS') == '1'
+                import os as _os3
+
+                import torch.distributed as _dist3
+
+                _save_cp3 = _os3.environ.get("SAVE_CP_TENSORS") == "1"
                 _cp_rank3 = _dist3.get_rank() if _dist3.is_initialized() else 0
-                _save_dir3 = _os3.environ.get('CP_TENSOR_DIR', '/tmp/claude/cp_tensors')
+                _save_dir3 = _os3.environ.get("CP_TENSOR_DIR", "/tmp/claude/cp_tensors")
+
                 def _save3(name, tensor):
-                    if not _save_cp3: return
+                    if not _save_cp3:
+                        return
                     _os3.makedirs(_save_dir3, exist_ok=True)
-                    path = f'{_save_dir3}/{name}_rank{_cp_rank3}.pt'
-                    if _os3.path.exists(path): return  # only save first forward pass
+                    path = f"{_save_dir3}/{name}_rank{_cp_rank3}.pt"
+                    if _os3.path.exists(path):
+                        return  # only save first forward pass
                     torch.save(tensor.detach().cpu(), path)
-                    print(f'[CP_SAVE] {name} shape={tuple(tensor.shape)} rank={_cp_rank3} → {path}', flush=True)
+                    print(f"[CP_SAVE] {name} shape={tuple(tensor.shape)} rank={_cp_rank3} → {path}", flush=True)
+
                 # output_orig shape: (T, 1, vocab) in THD
-                _save3('model_forward_output_logits', output_orig)
-                if 'label' in args:
-                    _save3('model_forward_flat_label', args['label'].squeeze(1) if args['label'].dim() == 2 else args['label'])
+                _save3("model_forward_output_logits", output_orig)
+                if "label" in args:
+                    _save3(
+                        "model_forward_flat_label",
+                        args["label"].squeeze(1) if args["label"].dim() == 2 else args["label"],
+                    )
                 output_dict = logits_processor(output_orig, **args)
-                if isinstance(output_dict, dict) and 'log_probs' in output_dict:
-                    _lp = output_dict['log_probs']
+                if isinstance(output_dict, dict) and "log_probs" in output_dict:
+                    _lp = output_dict["log_probs"]
                     if isinstance(_lp, torch.Tensor) and not _lp.is_nested:
-                        _save3('before_restore_log_probs_flat', _lp.reshape(-1))
+                        _save3("before_restore_log_probs_flat", _lp.reshape(-1))
                 output = {
                     k: postprocess_thd_engine(
-                        v, packed_seq_params, input_ids, batch_size, post_process=post_process, local_cp_size=local_cp_size
+                        v,
+                        packed_seq_params,
+                        input_ids,
+                        batch_size,
+                        post_process=post_process,
+                        local_cp_size=local_cp_size,
                     )
                     for k, v in output_dict.items()
                 }
-                if isinstance(output, dict) and 'log_probs' in output:
-                    _lp_post = output['log_probs']
+                if isinstance(output, dict) and "log_probs" in output:
+                    _lp_post = output["log_probs"]
                     if isinstance(_lp_post, torch.Tensor) and not _lp_post.is_nested:
-                        _save3('after_restore_log_probs_flat', _lp_post.flatten())
+                        _save3("after_restore_log_probs_flat", _lp_post.flatten())
             else:
                 output = postprocess_thd_engine(
                     output_orig,
@@ -607,17 +641,19 @@ def gptmodel_forward_model_engine(
 
     # MEM_DUMP: save snapshot after first forward pass
     if _mem_tag and _mem_rank0:
-        import torch as _t, os as _os
-        snap_path = _os.path.join(_mem_dir, f'{_mem_tag}_snapshot.pickle')
+        import os as _os
+
+        _dev = get_torch_device()
+        snap_path = _os.path.join(_mem_dir, f"{_mem_tag}_snapshot.pickle")
         if not _os.path.exists(snap_path):  # only first call
-            _t.cuda.memory._dump_snapshot(snap_path)
-            peak_mb = _t.cuda.max_memory_allocated() / 1e6
-            summ_path = _os.path.join(_mem_dir, f'{_mem_tag}_mem_summary.txt')
-            with open(summ_path, 'w') as _f:
+            _dev.memory._dump_snapshot(snap_path)
+            peak_mb = _dev.max_memory_allocated() / 1e6
+            summ_path = _os.path.join(_mem_dir, f"{_mem_tag}_mem_summary.txt")
+            with open(summ_path, "w") as _f:
                 _f.write(f"tag={_mem_tag}\n")
                 _f.write(f"peak_allocated_MB={peak_mb:.1f}\n")
-                _f.write(_t.cuda.memory_summary())
+                _f.write(_dev.memory_summary())
             print(f"[MEM_DUMP] {_mem_tag}: peak={peak_mb:.1f}MB → {snap_path}", flush=True)
-        _t.cuda.memory._record_memory_history(enabled=None)
+        _dev.memory._record_memory_history(enabled=None)
 
     return output

--- a/verl/models/mcore/prefix_tree_merge.py
+++ b/verl/models/mcore/prefix_tree_merge.py
@@ -30,20 +30,22 @@ Patch chain (each wrapper accepts ``magi_attention_key``/``flex_attention_key`` 
 The ``_magi_attn_forward`` helper (dispatch → calc_attn → undispatch) is copied
 verbatim from the fork and lives here so no Megatron source modification is needed.
 """
+
 from __future__ import annotations
 
 import functools
 import threading
-from typing import Optional
 
 import torch
 from torch import Tensor
 
+from verl.utils.device import get_torch_device
+
 # Module-level capture state for COMPARE_LAYERS=1 debugging
 _layer_capture: dict = {}
-_layer_counter: dict = {'magi': 0, 'flex': 0, 'fa': 0}  # per-attn-type layer counters
-_current_layer_idx: list = [-1]   # set by _sa_forward, read by _magi_attn_forward
-_current_attn_type: list = ['fa']  # set by _sa_forward, read by _magi_attn_forward
+_layer_counter: dict = {"magi": 0, "flex": 0, "fa": 0}  # per-attn-type layer counters
+_current_layer_idx: list = [-1]  # set by _sa_forward, read by _magi_attn_forward
+_current_attn_type: list = ["fa"]  # set by _sa_forward, read by _magi_attn_forward
 # When COMPARE_LAYERS=2, save full hidden state tensors (not just stats)
 _layer_tensors: dict = {}  # key -> Tensor on CPU
 
@@ -58,6 +60,7 @@ _magi_rope_bypass: threading.local = threading.local()
 # ---------------------------------------------------------------------------
 # flex_attention helper for prefix-tree
 # ---------------------------------------------------------------------------
+
 
 def _flex_attn_forward(
     query: Tensor,
@@ -76,26 +79,29 @@ def _flex_attn_forward(
     from torch.nn.attention.flex_attention import flex_attention
 
     T, _, H, D = query.shape
-    q = query.squeeze(1).permute(1, 0, 2).unsqueeze(0)   # (1, H, T, D)
+    q = query.squeeze(1).permute(1, 0, 2).unsqueeze(0)  # (1, H, T, D)
     k = key.squeeze(1).permute(1, 0, 2).unsqueeze(0)
     v = value.squeeze(1).permute(1, 0, 2).unsqueeze(0)
-    enable_gqa = (q.shape[1] != k.shape[1])
+    enable_gqa = q.shape[1] != k.shape[1]
 
-    import time as _t; import torch.distributed as _dist
-    torch.cuda.synchronize()
+    import time as _t
+
+    import torch.distributed as _dist
+
+    get_torch_device().synchronize()
     _t0 = _t.perf_counter()
-    out = flex_attention(q, k, v, block_mask=flex_attention_key,
-                         enable_gqa=enable_gqa)  # (1, Hq, T, D)
-    torch.cuda.synchronize()
+    out = flex_attention(q, k, v, block_mask=flex_attention_key, enable_gqa=enable_gqa)  # (1, Hq, T, D)
+    get_torch_device().synchronize()
     if not _dist.is_initialized() or _dist.get_rank() == 0:
-        print(f"[FLEX-ATTN] T={T} {(_t.perf_counter()-_t0)*1000:.2f}ms", flush=True)
+        print(f"[FLEX-ATTN] T={T} {(_t.perf_counter() - _t0) * 1000:.2f}ms", flush=True)
     out = out.squeeze(0).permute(1, 0, 2)  # (T, Hq, D)
-    return out.reshape(T, 1, -1)           # (T, 1, Hq*D)
+    return out.reshape(T, 1, -1)  # (T, 1, Hq*D)
 
 
 # ---------------------------------------------------------------------------
 # MAGI attention kernel helper (verbatim from Megatron-LM-prefix-tree fork)
 # ---------------------------------------------------------------------------
+
 
 def _magi_attn_forward(
     query: Tensor,
@@ -113,39 +119,46 @@ def _magi_attn_forward(
     across TP to get full T tokens, then dispatch/calc_attn/undispatch across
     CP ranks, then scatter back to T/TP for SP-consistent output.
     """
-    from magi_attention.api import calc_attn, dispatch, undispatch
-    import os as _os, torch as _torch, torch.distributed as _dist
+    import os as _os
 
-    q = query.squeeze(1)   # (T, np, hn) — already full T (Megatron gathers SP before calling here)
+    import torch as _torch
+    import torch.distributed as _dist
+    from magi_attention.api import calc_attn, dispatch, undispatch
+
+    q = query.squeeze(1)  # (T, np, hn) — already full T (Megatron gathers SP before calling here)
     k = key.squeeze(1)
     v = value.squeeze(1)
     _gathered = False
 
-    _save_cp = _os.environ.get('SAVE_CP_TENSORS') == '1'
+    _save_cp = _os.environ.get("SAVE_CP_TENSORS") == "1"
     _cp_rank = _dist.get_rank() if _dist.is_initialized() else 0
-    _save_dir = _os.environ.get('CP_TENSOR_DIR', '/tmp/claude/cp_tensors')
+    _save_dir = _os.environ.get("CP_TENSOR_DIR", "/tmp/claude/cp_tensors")
     # Layer index and attn type set by _sa_forward (which owns the counter increment)
     _layer_idx = _current_layer_idx[0]
     _atype = _current_attn_type[0]
 
     def _save(name, tensor):
-        if not _save_cp: return
+        if not _save_cp:
+            return
         _os.makedirs(_save_dir, exist_ok=True)
-        path = f'{_save_dir}/{_atype}_{name}_rank{_cp_rank}_layer{_layer_idx}.pt'
+        path = f"{_save_dir}/{_atype}_{name}_rank{_cp_rank}_layer{_layer_idx}.pt"
         _torch.save(tensor.detach().cpu(), path)
-        print(f'[CP_SAVE] {_atype}_{name} shape={tuple(tensor.shape)} rank={_cp_rank} layer={_layer_idx} → {path}', flush=True)
+        print(
+            f"[CP_SAVE] {_atype}_{name} shape={tuple(tensor.shape)} rank={_cp_rank} layer={_layer_idx} → {path}",
+            flush=True,
+        )
 
     # before_dispatch_Q/K/V saved by _sa_forward wrapper (covers both FA3 and MAGI)
     dq = dispatch(q, magi_attention_key)
     dk = dispatch(k, magi_attention_key)
     dv = dispatch(v, magi_attention_key)
 
-    _save('after_dispatch_Q', dq)
-    _save('after_dispatch_K', dk)
-    _save('after_dispatch_V', dv)
+    _save("after_dispatch_Q", dq)
+    _save("after_dispatch_K", dk)
+    _save("after_dispatch_V", dv)
 
     out, _ = calc_attn(dq, dk, dv, magi_attention_key)
-    _save('after_calc_attn_out', out)
+    _save("after_calc_attn_out", out)
 
     out = undispatch(out, magi_attention_key)
     # after_undispatch_out saved by _sa_forward wrapper
@@ -157,6 +170,7 @@ def _magi_attn_forward(
 # Patch application
 # ---------------------------------------------------------------------------
 
+
 def apply_prefix_tree_patch() -> None:
     """Monkey-patch upstream Megatron-LM classes to support prefix-tree attention (flex and MAGI).
 
@@ -164,10 +178,10 @@ def apply_prefix_tree_patch() -> None:
     ``_magi_patched`` sentinel attribute).
     """
     from megatron.core.extensions.transformer_engine import TEDotProductAttention
-    from megatron.core.transformer.attention import SelfAttention
-    from megatron.core.transformer.transformer_layer import TransformerLayer
-    from megatron.core.transformer.transformer_block import TransformerBlock
     from megatron.core.models.gpt.gpt_model import GPTModel
+    from megatron.core.transformer.attention import SelfAttention
+    from megatron.core.transformer.transformer_block import TransformerBlock
+    from megatron.core.transformer.transformer_layer import TransformerLayer
 
     if getattr(TEDotProductAttention, "_prefix_tree_patched", False):
         return  # already patched
@@ -178,25 +192,47 @@ def apply_prefix_tree_patch() -> None:
     _orig_te_forward = TEDotProductAttention.forward
 
     @functools.wraps(_orig_te_forward)
-    def _te_forward(self, query, key, value, attention_mask, attn_mask_type,
-                    attention_bias=None, packed_seq_params=None, num_splits=None,
-                    magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _te_forward(
+        self,
+        query,
+        key,
+        value,
+        attention_mask,
+        attn_mask_type,
+        attention_bias=None,
+        packed_seq_params=None,
+        num_splits=None,
+        magi_attention_key=None,
+        flex_attention_key=None,
+        **kwargs,
+    ):
         if magi_attention_key is not None:
             return _magi_attn_forward(query, key, value, magi_attention_key)
         if flex_attention_key is not None:
             return _flex_attn_forward(query, key, value, flex_attention_key)
         # FA3 path — Q/K/V and output are saved in _sa_forward via core_attention wrapper
-        import time as _t, torch as _torch, torch.distributed as _dist
-        _torch.cuda.synchronize()
+        import time as _t
+
+        import torch.distributed as _dist
+
+        get_torch_device().synchronize()
         _t0 = _t.perf_counter()
-        out = _orig_te_forward(self, query, key, value, attention_mask, attn_mask_type,
-                               attention_bias=attention_bias,
-                               packed_seq_params=packed_seq_params,
-                               num_splits=num_splits, **kwargs)
-        _torch.cuda.synchronize()
+        out = _orig_te_forward(
+            self,
+            query,
+            key,
+            value,
+            attention_mask,
+            attn_mask_type,
+            attention_bias=attention_bias,
+            packed_seq_params=packed_seq_params,
+            num_splits=num_splits,
+            **kwargs,
+        )
+        get_torch_device().synchronize()
         if not _dist.is_initialized() or _dist.get_rank() == 0:
             T = query.shape[0]
-            print(f"[FA3-ATTN] T={T} {(_t.perf_counter()-_t0)*1000:.2f}ms", flush=True)
+            print(f"[FA3-ATTN] T={T} {(_t.perf_counter() - _t0) * 1000:.2f}ms", flush=True)
         return out
 
     TEDotProductAttention.forward = _te_forward
@@ -207,12 +243,22 @@ def apply_prefix_tree_patch() -> None:
     _orig_sa_ckpt = SelfAttention._checkpointed_attention_forward
 
     @functools.wraps(_orig_sa_ckpt)
-    def _sa_ckpt_forward(self, query, key, value, attention_mask,
-                         rotary_pos_emb=None, attn_mask_type=None,
-                         attention_bias=None, packed_seq_params=None,
-                         magi_attention_key=None, flex_attention_key=None, **kwargs):
-        from megatron.core.transformer.attention import AttnMaskType
+    def _sa_ckpt_forward(
+        self,
+        query,
+        key,
+        value,
+        attention_mask,
+        rotary_pos_emb=None,
+        attn_mask_type=None,
+        attention_bias=None,
+        packed_seq_params=None,
+        magi_attention_key=None,
+        flex_attention_key=None,
+        **kwargs,
+    ):
         from megatron.core.tensor_parallel.random import checkpoint as tensor_parallel_checkpoint
+        from megatron.core.transformer.attention import AttnMaskType
 
         try:
             from megatron.core.transformer.utils import apply_module
@@ -225,7 +271,10 @@ def apply_prefix_tree_patch() -> None:
             # Keys are already injected via _ca_forward_with_key wrapper on self.core_attention
             # (set by _sa_forward before calling _orig_sa_forward). Don't pass them again.
             return apply_module(self.core_attention)(
-                q, k, v, amask,
+                q,
+                k,
+                v,
+                amask,
                 attn_mask_type=_attn_mask_type,
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
@@ -235,8 +284,14 @@ def apply_prefix_tree_patch() -> None:
             attn_mask_type = self.attn_mask_type
         attn_mask_type_tensor = torch.tensor([attn_mask_type.value], dtype=torch.int)
         return tensor_parallel_checkpoint(
-            custom_forward, False,
-            query, key, value, attention_mask, rotary_pos_emb, attn_mask_type_tensor,
+            custom_forward,
+            False,
+            query,
+            key,
+            value,
+            attention_mask,
+            rotary_pos_emb,
+            attn_mask_type_tensor,
         )
 
     SelfAttention._checkpointed_attention_forward = _sa_ckpt_forward
@@ -247,38 +302,50 @@ def apply_prefix_tree_patch() -> None:
     _orig_sa_forward = SelfAttention.forward
 
     @functools.wraps(_orig_sa_forward)
-    def _sa_forward(self, hidden_states, attention_mask,
-                    magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _sa_forward(self, hidden_states, attention_mask, magi_attention_key=None, flex_attention_key=None, **kwargs):
         attn_key = magi_attention_key or flex_attention_key
         _real_ca_forward = self.core_attention.forward
 
-        import os as _os, torch as _torch, torch.distributed as _dist
-        _save_cp = _os.environ.get('SAVE_CP_TENSORS') == '1'
+        import os as _os
+
+        import torch as _torch
+        import torch.distributed as _dist
+
+        _save_cp = _os.environ.get("SAVE_CP_TENSORS") == "1"
         _cp_rank = _dist.get_rank() if _dist.is_initialized() else 0
-        _save_dir = _os.environ.get('CP_TENSOR_DIR', '/tmp/claude/cp_tensors')
-        _atype = 'magi' if magi_attention_key else ('flex' if flex_attention_key else 'fa')
+        _save_dir = _os.environ.get("CP_TENSOR_DIR", "/tmp/claude/cp_tensors")
+        _atype = "magi" if magi_attention_key else ("flex" if flex_attention_key else "fa")
         _layer_idx = _layer_counter[_atype]
         _layer_counter[_atype] += 1
-        _current_layer_idx[0] = _layer_idx   # share with _magi_attn_forward
-        _current_attn_type[0] = _atype        # share with _magi_attn_forward
+        _current_layer_idx[0] = _layer_idx  # share with _magi_attn_forward
+        _current_attn_type[0] = _atype  # share with _magi_attn_forward
 
         def _save_sa(name, tensor):
-            if not _save_cp: return
+            if not _save_cp:
+                return
             _os.makedirs(_save_dir, exist_ok=True)
-            path = f'{_save_dir}/{_atype}_{name}_rank{_cp_rank}_layer{_layer_idx}.pt'
+            path = f"{_save_dir}/{_atype}_{name}_rank{_cp_rank}_layer{_layer_idx}.pt"
             _torch.save(tensor.detach().cpu(), path)
-            print(f'[CP_SAVE] {_atype}_{name} shape={tuple(tensor.shape)} rank={_cp_rank} layer={_layer_idx} → {path}', flush=True)
+            print(
+                f"[CP_SAVE] {_atype}_{name} shape={tuple(tensor.shape)} rank={_cp_rank} layer={_layer_idx} → {path}",
+                flush=True,
+            )
 
         @functools.wraps(_real_ca_forward)
         def _ca_forward_with_key(q, k, v, *args, **kw):
-            _save_sa('before_dispatch_Q', q.squeeze(1) if q.dim() == 4 else q)
-            _save_sa('before_dispatch_K', k.squeeze(1) if k.dim() == 4 else k)
-            _save_sa('before_dispatch_V', v.squeeze(1) if v.dim() == 4 else v)
-            out = _real_ca_forward(q, k, v, *args,
-                                   magi_attention_key=magi_attention_key if attn_key else None,
-                                   flex_attention_key=flex_attention_key if attn_key else None,
-                                   **kw)
-            _save_sa('after_undispatch_out', out.squeeze(1) if out.dim() == 3 else out)
+            _save_sa("before_dispatch_Q", q.squeeze(1) if q.dim() == 4 else q)
+            _save_sa("before_dispatch_K", k.squeeze(1) if k.dim() == 4 else k)
+            _save_sa("before_dispatch_V", v.squeeze(1) if v.dim() == 4 else v)
+            out = _real_ca_forward(
+                q,
+                k,
+                v,
+                *args,
+                magi_attention_key=magi_attention_key if attn_key else None,
+                flex_attention_key=flex_attention_key if attn_key else None,
+                **kw,
+            )
+            _save_sa("after_undispatch_out", out.squeeze(1) if out.dim() == 3 else out)
             return out
 
         self.core_attention.forward = _ca_forward_with_key
@@ -296,8 +363,7 @@ def apply_prefix_tree_patch() -> None:
     _orig_tl_forward = TransformerLayer.forward
 
     @functools.wraps(_orig_tl_forward)
-    def _tl_forward(self, hidden_states, attention_mask,
-                    magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _tl_forward(self, hidden_states, attention_mask, magi_attention_key=None, flex_attention_key=None, **kwargs):
         attn_key = magi_attention_key or flex_attention_key
         if attn_key is None:
             out = _orig_tl_forward(self, hidden_states, attention_mask, **kwargs)
@@ -306,9 +372,9 @@ def apply_prefix_tree_patch() -> None:
 
             @functools.wraps(_real_sa_forward)
             def _sa_forward_with_key(*args, **kw):
-                return _real_sa_forward(*args,
-                                        magi_attention_key=magi_attention_key,
-                                        flex_attention_key=flex_attention_key, **kw)
+                return _real_sa_forward(
+                    *args, magi_attention_key=magi_attention_key, flex_attention_key=flex_attention_key, **kw
+                )
 
             self.self_attention.forward = _sa_forward_with_key
             try:
@@ -318,14 +384,15 @@ def apply_prefix_tree_patch() -> None:
 
         # COMPARE_LAYERS: capture forward hidden state + backward gradient per layer
         import os as _os
-        _cl = _os.environ.get('COMPARE_LAYERS', '0')
-        if _cl in ('1', '2'):
+
+        _cl = _os.environ.get("COMPARE_LAYERS", "0")
+        if _cl in ("1", "2"):
             import torch.distributed as _dist
+
             hs_out = out[0] if isinstance(out, tuple) else out
             idx = _layer_counter[0]
-            tag = 'flex' if flex_attention_key is not None else \
-                  'magi' if magi_attention_key is not None else 'fa3'
-            key = f'{tag}_{idx}'
+            tag = "flex" if flex_attention_key is not None else "magi" if magi_attention_key is not None else "fa3"
+            key = f"{tag}_{idx}"
             # Only capture every 5 layers (0, 5, 10, ...) to see trend without huge files
             _layer_counter[0] += 1
             if idx % 5 != 0 or key in _layer_capture:
@@ -337,11 +404,12 @@ def apply_prefix_tree_patch() -> None:
                 if _dist.is_initialized():
                     try:
                         from megatron.core import mpu
+
                         tp_group = mpu.get_tensor_model_parallel_group()
-                        tp_size  = mpu.get_tensor_model_parallel_world_size()
+                        tp_size = mpu.get_tensor_model_parallel_world_size()
                     except Exception:
                         tp_group = None
-                        tp_size  = _dist.get_world_size()
+                        tp_size = _dist.get_world_size()
                     gathered = [torch.zeros_like(h_local) for _ in range(tp_size)]
                     _dist.all_gather(gathered, h_local, group=tp_group)
                     h = torch.cat(gathered, dim=0)  # (T_full, 1, H)
@@ -349,26 +417,29 @@ def apply_prefix_tree_patch() -> None:
                     h = h_local
                 if not _dist.is_initialized() or _dist.get_rank() == 0:
                     _layer_capture[key] = {
-                        'fwd_mean': h.mean().item(),
-                        'fwd_std':  h.std().item(),
-                        'fwd_norm': h.norm().item(),
-                        'shape': list(h.shape),
+                        "fwd_mean": h.mean().item(),
+                        "fwd_std": h.std().item(),
+                        "fwd_norm": h.norm().item(),
+                        "shape": list(h.shape),
                     }
                     # COMPARE_LAYERS=2: also save full tensor to disk for per-token diff
-                    if _cl == '2':
+                    if _cl == "2":
                         _layer_tensors[key] = h.cpu()
                     # Capture gradient via retain_grad + hook
                     _bwd_key = key
-                    def _make_bwd_hook(bk, save_full=(_cl == '2')):
+
+                    def _make_bwd_hook(bk, save_full=(_cl == "2")):
                         def _bwd(grad):
-                            if bk in _layer_capture and 'bwd_norm' not in _layer_capture[bk]:
+                            if bk in _layer_capture and "bwd_norm" not in _layer_capture[bk]:
                                 g = grad.detach().float()
-                                _layer_capture[bk]['bwd_mean'] = g.mean().item()
-                                _layer_capture[bk]['bwd_std']  = g.std().item()
-                                _layer_capture[bk]['bwd_norm'] = g.norm().item()
+                                _layer_capture[bk]["bwd_mean"] = g.mean().item()
+                                _layer_capture[bk]["bwd_std"] = g.std().item()
+                                _layer_capture[bk]["bwd_norm"] = g.norm().item()
                                 if save_full:
-                                    _layer_tensors[bk + '_bwd'] = g.cpu()
+                                    _layer_tensors[bk + "_bwd"] = g.cpu()
+
                         return _bwd
+
                     if hs_out.requires_grad:
                         hs_out.retain_grad()
                         hs_out.register_hook(_make_bwd_hook(_bwd_key))
@@ -382,8 +453,7 @@ def apply_prefix_tree_patch() -> None:
     _orig_tb_forward = TransformerBlock.forward
 
     @functools.wraps(_orig_tb_forward)
-    def _tb_forward(self, hidden_states, attention_mask,
-                    magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _tb_forward(self, hidden_states, attention_mask, magi_attention_key=None, flex_attention_key=None, **kwargs):
         attn_key = magi_attention_key or flex_attention_key
         if attn_key is None:
             return _orig_tb_forward(self, hidden_states, attention_mask, **kwargs)
@@ -395,16 +465,17 @@ def apply_prefix_tree_patch() -> None:
             def _make_wrapper(orig):
                 @functools.wraps(orig)
                 def _w(*args, **kw):
-                    return orig(*args,
-                                magi_attention_key=magi_attention_key,
-                                flex_attention_key=flex_attention_key, **kw)
+                    return orig(
+                        *args, magi_attention_key=magi_attention_key, flex_attention_key=flex_attention_key, **kw
+                    )
+
                 return _w
 
             layer.forward = _make_wrapper(_orig)
         try:
             out = _orig_tb_forward(self, hidden_states, attention_mask, **kwargs)
         finally:
-            for layer, orig_fwd in zip(self.layers, originals):
+            for layer, orig_fwd in zip(self.layers, originals, strict=False):
                 layer.forward = orig_fwd
         return out
 
@@ -418,8 +489,9 @@ def apply_prefix_tree_patch() -> None:
     _orig_gpt_forward = GPTModel.forward
 
     @functools.wraps(_orig_gpt_forward)
-    def _gpt_forward(self, input_ids, position_ids, attention_mask,
-                     magi_attention_key=None, flex_attention_key=None, **kwargs):
+    def _gpt_forward(
+        self, input_ids, position_ids, attention_mask, magi_attention_key=None, flex_attention_key=None, **kwargs
+    ):
         attn_key = magi_attention_key or flex_attention_key
         if attn_key is None:
             return _orig_gpt_forward(self, input_ids, position_ids, attention_mask, **kwargs)
@@ -427,12 +499,12 @@ def apply_prefix_tree_patch() -> None:
 
         @functools.wraps(_real_decoder_forward)
         def _decoder_forward_with_key(*args, **kw):
-            return _real_decoder_forward(*args,
-                                         magi_attention_key=magi_attention_key,
-                                         flex_attention_key=flex_attention_key, **kw)
+            return _real_decoder_forward(
+                *args, magi_attention_key=magi_attention_key, flex_attention_key=flex_attention_key, **kw
+            )
 
         self.decoder.forward = _decoder_forward_with_key
-        _prev_rope_bypass = getattr(_magi_rope_bypass, 'active', False)
+        _prev_rope_bypass = getattr(_magi_rope_bypass, "active", False)
         _magi_rope_bypass.active = True  # all prefix-tree paths bypass CP RoPE slicing
         try:
             out = _orig_gpt_forward(self, input_ids, position_ids, attention_mask, **kwargs)
@@ -456,20 +528,20 @@ def apply_prefix_tree_patch() -> None:
     # in BSHD attention, so correctness is maintained regardless of CP rank.
     # ------------------------------------------------------------------
     from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
-    _orig_rope_cached = RotaryEmbedding.forward           # lru_cache wrapper
-    _orig_rope_fn = RotaryEmbedding.forward.__wrapped__   # actual function body
+
+    _orig_rope_cached = RotaryEmbedding.forward  # lru_cache wrapper
+    _orig_rope_fn = RotaryEmbedding.forward.__wrapped__  # actual function body
 
     def _rope_forward_pt(self, max_seq_len, offset=0, packed_seq=False, cp_group=None):
-        if getattr(_magi_rope_bypass, 'active', False):
+        if getattr(_magi_rope_bypass, "active", False):
             # Bypass CP slice: return full-sequence freqs identical on all CP ranks.
             # get_rotary_seq_len multiplies by cp_size (yielding 2T for CP=2), so we
             # divide it back out here to get the true flat-sequence length T.
-            _cp = cp_group or getattr(self, 'cp_group', None)
+            _cp = cp_group or getattr(self, "cp_group", None)
             _cp_size = _cp.size() if _cp is not None else 1
             actual_seq_len = max_seq_len // _cp_size
             return _orig_rope_fn(self, actual_seq_len, offset=offset, packed_seq=True, cp_group=None)
-        return _orig_rope_cached(self, max_seq_len, offset=offset,
-                                 packed_seq=packed_seq, cp_group=cp_group)
+        return _orig_rope_cached(self, max_seq_len, offset=offset, packed_seq=packed_seq, cp_group=cp_group)
 
     RotaryEmbedding.forward = _rope_forward_pt
 

--- a/verl/models/mcore/prefix_tree_merge.py
+++ b/verl/models/mcore/prefix_tree_merge.py
@@ -51,6 +51,9 @@ _layer_tensors: dict = {}  # key -> Tensor on CPU
 # Set in model_forward.py before calling model(), cleared after.
 _active_magi_key: threading.local = threading.local()
 
+# Set to True during prefix-tree forward to bypass CP-rank-specific RoPE slicing.
+_magi_rope_bypass: threading.local = threading.local()
+
 
 # ---------------------------------------------------------------------------
 # flex_attention helper for prefix-tree
@@ -409,6 +412,8 @@ def apply_prefix_tree_patch() -> None:
 
     # ------------------------------------------------------------------
     # 6. GPTModel.forward — accept and pass magi/flex attention key.
+    #    Also sets _magi_rope_bypass.active=True so patch #7 below skips
+    #    the CP-rank-specific RoPE slicing for the duration of the call.
     # ------------------------------------------------------------------
     _orig_gpt_forward = GPTModel.forward
 
@@ -427,13 +432,46 @@ def apply_prefix_tree_patch() -> None:
                                          flex_attention_key=flex_attention_key, **kw)
 
         self.decoder.forward = _decoder_forward_with_key
+        _prev_rope_bypass = getattr(_magi_rope_bypass, 'active', False)
+        _magi_rope_bypass.active = True  # all prefix-tree paths bypass CP RoPE slicing
         try:
             out = _orig_gpt_forward(self, input_ids, position_ids, attention_mask, **kwargs)
         finally:
             self.decoder.forward = _real_decoder_forward
+            _magi_rope_bypass.active = _prev_rope_bypass
         return out
 
     GPTModel.forward = _gpt_forward
+
+    # ------------------------------------------------------------------
+    # 7. RotaryEmbedding.forward — bypass CP-rank RoPE slicing for prefix-tree.
+    #
+    # Root cause of CP>1 bug: with BSHD format (packed_seq=False), Megatron slices
+    # rotary position frequencies per CP rank via get_pos_emb_on_this_cp_rank.
+    # MAGI/flex prefix-tree passes the full T-token sequence to every CP rank;
+    # different per-rank RoPE rotations produce different Q/K values → wrong attention.
+    #
+    # Fix: when prefix-tree is active (_magi_rope_bypass.active=True), skip CP slicing
+    # and return the full-sequence frequencies.  Only positions [0..T-1] are applied
+    # in BSHD attention, so correctness is maintained regardless of CP rank.
+    # ------------------------------------------------------------------
+    from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
+    _orig_rope_cached = RotaryEmbedding.forward           # lru_cache wrapper
+    _orig_rope_fn = RotaryEmbedding.forward.__wrapped__   # actual function body
+
+    def _rope_forward_pt(self, max_seq_len, offset=0, packed_seq=False, cp_group=None):
+        if getattr(_magi_rope_bypass, 'active', False):
+            # Bypass CP slice: return full-sequence freqs identical on all CP ranks.
+            # get_rotary_seq_len multiplies by cp_size (yielding 2T for CP=2), so we
+            # divide it back out here to get the true flat-sequence length T.
+            _cp = cp_group or getattr(self, 'cp_group', None)
+            _cp_size = _cp.size() if _cp is not None else 1
+            actual_seq_len = max_seq_len // _cp_size
+            return _orig_rope_fn(self, actual_seq_len, offset=offset, packed_seq=True, cp_group=None)
+        return _orig_rope_cached(self, max_seq_len, offset=offset,
+                                 packed_seq=packed_seq, cp_group=cp_group)
+
+    RotaryEmbedding.forward = _rope_forward_pt
 
     TEDotProductAttention._prefix_tree_patched = True
 

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -72,6 +72,104 @@ def apply_prefix_grouper_patch():
     print(f"[PrefixGrouper] Patched: {patched}")
 
 
+# ---------------------------------------------------------------------------
+# FSDP-only: dynamic prefix-tree + Magi backend.
+#
+# Registers ``"Magi_Attention"`` into HF's ``ALL_ATTENTION_FUNCTIONS``. With
+# ``model.config._attn_implementation = "Magi_Attention"``, every attention
+# layer dispatches through the backend, which reads the Magi key off a
+# per-module attribute. Megatron does not use this path — it builds its own
+# Magi/flex key in ``verl/utils/prefix_tree_magi.py`` and calls
+# ``magi_attn_flex_key`` directly.
+# ---------------------------------------------------------------------------
+
+_MAGI_PREFIX_TREE_REGISTERED = False
+
+
+def _is_attention_module(mod) -> bool:
+    cls_name = mod.__class__.__name__.lower()
+    return cls_name.endswith("attention") or cls_name.endswith("self_attn") or cls_name.endswith("selfattention")
+
+
+def set_magi_attention_key_fsdp(model, key) -> None:
+    """FSDP-only. Attach ``key`` to every attention layer as ``_verl_magi_attention_key``.
+
+    Used by the FSDP dynamic-trie path so the HF ``Magi_Attention`` backend
+    (``_magi_prefix_tree_attention_forward_fsdp``) can read the per-step Magi
+    runtime key. Megatron does NOT use this — it threads the key directly via
+    ``magi_attention_key=...`` kwarg into mcore's forward.
+
+    Module attribute (not kwargs / ContextVar): kwargs crash FSDP2 mixed-precision
+    casting on the dataclass key, ContextVar resets before activation-checkpoint
+    backward recompute. Attribute survives both; same pattern as ``cp_group``.
+    """
+    for _, mod in model.named_modules():
+        if _is_attention_module(mod):
+            mod._verl_magi_attention_key = key
+
+
+def _magi_prefix_tree_attention_forward_fsdp(
+    module,
+    query,
+    key,
+    value,
+    attention_mask,
+    scaling=None,
+    dropout: float = 0.0,
+    **kwargs,
+):
+    """FSDP-only. HF-compatible attention forward backed by MagiAttention's FFA kernel.
+
+    Registered into ``ALL_ATTENTION_FUNCTIONS`` under the name ``"Magi_Attention"``
+    by ``apply_magi_prefix_tree_backend_fsdp``. Megatron uses its own attention
+    integration in ``verl/utils/prefix_tree_magi.py`` and does not go through
+    this function.
+
+    Q/K/V are (bsz, num_heads, seq_len, head_dim); bsz must be 1 since the
+    prefix-tree path packs all samples into one sequence. Patterned after
+    https://github.com/SandAI-org/MagiAttention/blob/main/examples/transformers/magi_attention_func.py.
+    """
+    from einops import rearrange
+    from magi_attention.api import calc_attn
+
+    magi_key = getattr(module, "_verl_magi_attention_key", None)
+    assert magi_key is not None, "set_magi_attention_key_fsdp must be called before forward."
+
+    cp_group = getattr(module, "cp_group", None)
+    assert cp_group is not None or not torch.distributed.is_initialized(), (
+        "attention module missing cp_group; did FSDPEngine attach it?"
+    )
+
+    bsz = query.shape[0]
+    assert bsz == 1, f"Magi_Attention backend requires batch_size=1, got {bsz}."
+
+    dtype = query.dtype
+    # (1, nh, s, hd) -> (s, nh, hd); FFA needs fp16/bf16.
+    q, k, v = [rearrange(e, "1 nh s hd -> (1 s) nh hd").to(torch.bfloat16) for e in (query, key, value)]
+
+    o = calc_attn(q, k, v, magi_key)[0]
+
+    o = rearrange(o, "(1 s) nh hd -> 1 s (nh hd)").to(dtype)
+    return o, None
+
+
+def apply_magi_prefix_tree_backend_fsdp():
+    """FSDP-only. Idempotently register ``"Magi_Attention"`` into ALL_ATTENTION_FUNCTIONS.
+
+    Megatron does not register an HF backend — its prefix-tree path runs through
+    mcore's forward in ``verl/models/mcore/model_forward.py``.
+    """
+    global _MAGI_PREFIX_TREE_REGISTERED
+    if _MAGI_PREFIX_TREE_REGISTERED:
+        return
+
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    ALL_ATTENTION_FUNCTIONS.register("Magi_Attention", _magi_prefix_tree_attention_forward_fsdp)
+    _MAGI_PREFIX_TREE_REGISTERED = True
+    print("[PrefixTreeDynamic-FSDP] Registered Magi_Attention backend in ALL_ATTENTION_FUNCTIONS")
+
+
 def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     """
     This is the equivalent of torch.repeat_interleave(x, dim=2, repeats=n_rep). The hidden states go from (batch,
@@ -295,6 +393,7 @@ def apply_monkey_patch(
     use_fused_kernels: bool = False,
     fused_kernels_backend: str = None,
     use_prefix_grouper: bool = False,
+    use_prefix_tree_dynamic: bool = False,
     use_tiled_mlp: bool = False,
     tiled_mlp_shards: int = 4,
 ):
@@ -323,6 +422,12 @@ def apply_monkey_patch(
     # Apply PrefixGrouper patch if enabled
     if use_prefix_grouper:
         apply_prefix_grouper_patch()
+
+    # FSDP-only: register the Magi_Attention backend if dynamic prefix-tree is on.
+    # FSDPEngine._build_module then walks the model, attaches `cp_group`, and
+    # flips `_attn_implementation`.
+    if use_prefix_tree_dynamic:
+        apply_magi_prefix_tree_backend_fsdp()
 
     """Replace _flash_attention_forward to _ulysses_flash_attention_forward"""
     module = sys.modules[model.__module__]

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -22,7 +22,6 @@ import json
 import os
 import uuid
 from collections import defaultdict
-from copy import deepcopy
 from pprint import pprint
 from typing import Any, Optional
 
@@ -34,7 +33,6 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
 from verl import DataProto
-from verl.experimental.dataset.sampler import AbstractCurriculumSampler
 from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
 from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup, ResourcePoolManager
 from verl.single_controller.ray.base import create_colocated_worker_cls
@@ -70,6 +68,7 @@ from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_
 from verl.utils.torch_functional import masked_mean
 from verl.utils.tracking import ValidationGenerationsLogger
 from verl.workers.config import DistillationConfig, EngineConfig
+from verl.workers.rollout.llm_server import LLMServerManager
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
 
 
@@ -313,7 +312,6 @@ class RayPPOTrainer:
             self.kl_ctrl_in_reward = core_algos.get_kl_controller(self.config.algorithm.kl_ctrl)
 
         self.use_prefix_grouper = self.config.actor_rollout_ref.actor.get("use_prefix_grouper", False)
-        self.use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
 
         self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
 
@@ -422,7 +420,7 @@ class RayPPOTrainer:
         lines = []
         for i in range(n):
             entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False))
+            lines.append(json.dumps(entry, ensure_ascii=False, default=str))
 
         with open(filename, "w") as f:
             f.write("\n".join(lines) + "\n")
@@ -445,9 +443,11 @@ class RayPPOTrainer:
             scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
             sample_gts = [item.non_tensor_batch.get("reward_model", {}).get("ground_truth", None) for item in batch]
 
-            reward_extra_infos_to_dump = reward_extra_infos_dict.copy()
+            reward_extra_infos_to_dump = {
+                k: (v.tolist() if isinstance(v, np.ndarray) else v) for k, v in reward_extra_infos_dict.items()
+            }
             if "request_id" in batch.non_tensor_batch:
-                reward_extra_infos_dict.setdefault(
+                reward_extra_infos_to_dump.setdefault(
                     "request_id",
                     batch.non_tensor_batch["request_id"].tolist(),
                 )
@@ -508,17 +508,6 @@ class RayPPOTrainer:
         assert self.reward_loop_manager is not None, "RewardLoopManager is None"
         batch_reward = self.reward_loop_manager.compute_rm_score(batch)
         return batch_reward
-
-    def _should_compute_teacher_colocate(self, batch: DataProto) -> bool:
-        return self.use_teacher_policy and not self.distillation_config.teacher_model.enable_resource_pool
-
-    def _compute_teacher_colocate(self, batch: DataProto) -> DataProto:
-        """Compute teacher logprobs after rollout when teacher and student are colocated."""
-        assert self.teacher_model_manager is not None, "TeacherModelManager is None"
-        teacher_batch = self.teacher_model_manager.compute_logprobs(batch)
-        if "teacher_multi_modal_data" in batch.non_tensor_batch:
-            batch.pop(non_tensor_batch_keys=["teacher_multi_modal_data"])
-        return teacher_batch
 
     def _validate(self, merged: bool = False):
         data_source_lst = []
@@ -729,22 +718,21 @@ class RayPPOTrainer:
 
             critic_cfg: CriticConfig = omega_conf_to_dataclass(self.config.critic)
 
-            if self.use_legacy_worker_impl == "disable":
-                # convert critic_cfg into TrainingWorkerConfig
-                from verl.workers.engine_workers import TrainingWorkerConfig
+            # convert critic_cfg into TrainingWorkerConfig for the unified model engine worker
+            from verl.workers.engine_workers import TrainingWorkerConfig
 
-                orig_critic_cfg = critic_cfg
-                engine_config: EngineConfig = orig_critic_cfg.engine
-                engine_config.infer_max_token_len_per_gpu = critic_cfg.ppo_infer_max_token_len_per_gpu
-                engine_config.max_token_len_per_gpu = critic_cfg.ppo_max_token_len_per_gpu
+            orig_critic_cfg = critic_cfg
+            engine_config: EngineConfig = orig_critic_cfg.engine
+            engine_config.infer_max_token_len_per_gpu = critic_cfg.ppo_infer_max_token_len_per_gpu
+            engine_config.max_token_len_per_gpu = critic_cfg.ppo_max_token_len_per_gpu
 
-                critic_cfg = TrainingWorkerConfig(
-                    model_type="value_model",
-                    model_config=orig_critic_cfg.model,
-                    engine_config=engine_config,
-                    optimizer_config=orig_critic_cfg.optim,
-                    checkpoint_config=orig_critic_cfg.checkpoint,
-                )
+            critic_cfg = TrainingWorkerConfig(
+                model_type="value_model",
+                model_config=orig_critic_cfg.model,
+                engine_config=engine_config,
+                optimizer_config=orig_critic_cfg.optim,
+                checkpoint_config=orig_critic_cfg.checkpoint,
+            )
 
             critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)
             self.resource_pool_to_cls[resource_pool][str(Role.Critic)] = critic_cls
@@ -763,7 +751,8 @@ class RayPPOTrainer:
         # NOTE: if you want to use a different resource pool for each role, which can support different parallel size,
         # you should not use `create_colocated_worker_cls`.
         # Instead, directly pass different resource pool to different worker groups.
-        # See https://github.com/volcengine/verl/blob/master/examples/ray/tutorial.ipynb for more information.
+        # See https://github.com/verl-project/verl/blob/master/examples/tutorial/ray/tutorial.ipynb
+        # for more information.
         all_wg = {}
         wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
         if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
@@ -795,17 +784,14 @@ class RayPPOTrainer:
 
         if self.use_critic:
             self.critic_wg = all_wg[str(Role.Critic)]
-            if self.use_legacy_worker_impl == "disable":
-                self.critic_wg.reset()
-                # assign critic loss
-                from functools import partial
+            self.critic_wg.reset()
+            # assign critic loss
+            from functools import partial
 
-                from verl.workers.utils.losses import value_loss
+            from verl.workers.utils.losses import value_loss
 
-                value_loss_ = partial(value_loss, config=orig_critic_cfg)
-                self.critic_wg.set_loss_fn(value_loss_)
-            else:
-                self.critic_wg.init_model()
+            value_loss_ = partial(value_loss, config=orig_critic_cfg)
+            self.critic_wg.set_loss_fn(value_loss_)
 
         if self.use_reference_policy and not self.ref_in_actor:
             if str(Role.RefPolicy) in all_wg:
@@ -841,11 +827,11 @@ class RayPPOTrainer:
 
         # initialize teacher loop manager
         if self.use_teacher_policy:
-            from verl.experimental.teacher_loop import TeacherModelManager
+            from verl.experimental.teacher_loop import MultiTeacherModelManager
 
             teacher_resource_pool = self.resource_pool_manager.get_resource_pool(Role.TeacherModel)
-            self.teacher_model_manager = TeacherModelManager(
-                config=self.config.distillation,
+            self.teacher_model_manager = MultiTeacherModelManager(
+                config=self.config,
                 resource_pool=teacher_resource_pool,
             )
             self.distillation_config: DistillationConfig = omega_conf_to_dataclass(self.config.distillation)
@@ -865,6 +851,10 @@ class RayPPOTrainer:
         # two conditions satisfied: (1) no reward model, or (2) reward model with extra resource pool
         enable_agent_reward_loop = not self.use_rm or self.config.reward.reward_model.enable_resource_pool
 
+        self.llm_server_manager = LLMServerManager.create(
+            config=self.config, worker_group=self.actor_rollout_wg, rollout_resource_pool=actor_rollout_resource_pool
+        )
+
         # if enable_agent_reward_loop, we directly pass reward_loop_workers to agent loop manager
         # to stream reward computation with actor rollout
         # To stream teacher computation with actor rollout, we instead pass the full manager so that the
@@ -872,10 +862,9 @@ class RayPPOTrainer:
         reward_loop_worker_handles = self.reward_loop_manager.reward_loop_workers if enable_agent_reward_loop else None
         self.async_rollout_manager = AgentLoopManager.create(
             config=self.config,
-            worker_group=self.actor_rollout_wg,
-            rollout_resource_pool=actor_rollout_resource_pool,
+            llm_client=self.llm_server_manager.get_client(),
+            teacher_client=self.teacher_model_manager.get_client() if self.use_teacher_policy else None,
             reward_loop_worker_handles=reward_loop_worker_handles,
-            teacher_model_manager=self.teacher_model_manager,
         )
 
         checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
@@ -888,7 +877,7 @@ class RayPPOTrainer:
         self.checkpoint_manager = CheckpointEngineManager(
             config=checkpoint_engine_config,
             trainer=self.actor_rollout_wg,
-            replicas=self.async_rollout_manager.rollout_replicas,
+            replicas=self.llm_server_manager.get_replicas(),
         )
 
         # sleep all replicas to load checkpoint
@@ -1139,79 +1128,78 @@ class RayPPOTrainer:
         metrics.update(global_balance_stats)
 
     def _compute_values(self, batch: DataProto) -> DataProto:
-        if self.use_legacy_worker_impl == "disable":
-            batch_td = batch.to_tensordict()
-            # step 2: convert from padding to nopadding
-            batch_td = left_right_2_no_padding(batch_td)
-            # step 3: add meta info
-            tu.assign_non_tensor(batch_td, compute_loss=False)
-            output = self.critic_wg.infer_batch(batch_td)
-            output = output.get()
-            values = tu.get(output, "values")
-            values = no_padding_2_padding(values, batch_td)
-            values = tu.get_tensordict({"values": values.float()})
-            values = DataProto.from_tensordict(values)
-        else:
-            values = self.critic_wg.compute_values(batch)
+        batch_td = batch.to_tensordict()
+        # step 2: convert from padding to nopadding
+        batch_td = left_right_2_no_padding(batch_td)
+        # step 3: add meta info
+        tu.assign_non_tensor(batch_td, compute_loss=False)
+        output = self.critic_wg.infer_batch(batch_td)
+        output = output.get()
+        values = tu.get(output, "values")
+        values = no_padding_2_padding(values, batch_td)
+        values = tu.get_tensordict({"values": values.float()})
+        values = DataProto.from_tensordict(values)
         return values
 
     def _compute_ref_log_prob(self, batch: DataProto) -> DataProto:
-        if self.use_legacy_worker_impl == "disable":
-            # step 1: convert dataproto to tensordict.
-            batch_td = batch.to_tensordict()
-            # step 2: convert from padding to nopadding
-            batch_td = left_right_2_no_padding(batch_td)
-            # step 3: add meta info
-            metadata = {"calculate_entropy": False, "compute_loss": False}
-            if self.ref_in_actor:
-                metadata["no_lora_adapter"] = True
-            tu.assign_non_tensor(batch_td, **metadata)
-            if self.ref_in_actor:
-                output = self.actor_rollout_wg.compute_log_prob(batch_td)
-            else:
-                output = self.ref_policy_wg.compute_ref_log_prob(batch_td)
-            # gather output
-            log_probs = tu.get(output, "log_probs")
-            # step 4. No padding to padding
-            log_probs = no_padding_2_padding(log_probs, batch_td)
-            # step 5: rebuild a tensordict and convert to dataproto
-            ref_log_prob = tu.get_tensordict({"ref_log_prob": log_probs.float()})
-            ref_log_prob = DataProto.from_tensordict(ref_log_prob)
+        # step 1: convert dataproto to tensordict.
+        batch_td = batch.to_tensordict()
+        # step 2: convert from padding to nopadding
+        batch_td = left_right_2_no_padding(batch_td)
+        # step 3: add meta info
+        metadata = {"calculate_entropy": False, "compute_loss": False}
+        if self.ref_in_actor:
+            metadata["no_lora_adapter"] = True
+        tu.assign_non_tensor(batch_td, **metadata)
+        if self.ref_in_actor:
+            output = self.actor_rollout_wg.compute_log_prob(batch_td)
         else:
-            ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
+            output = self.ref_policy_wg.compute_ref_log_prob(batch_td)
+        # gather output
+        log_probs = tu.get(output, "log_probs")
+        # step 4. No padding to padding
+        log_probs = no_padding_2_padding(log_probs, batch_td)
+        # step 5: rebuild a tensordict and convert to dataproto
+        ref_log_prob = tu.get_tensordict({"ref_log_prob": log_probs.float()})
+        ref_log_prob = DataProto.from_tensordict(ref_log_prob)
 
         return ref_log_prob
 
     def _compute_old_log_prob(self, batch: DataProto):
-        if self.use_legacy_worker_impl == "disable":
-            # TODO: remove step 1, 2, 4 after we make the whole training tensordict and padding free
-            # step 1: convert dataproto to tensordict.
-            batch_td = batch.to_tensordict()
-            # step 2: convert from padding to nopadding
-            batch_td = left_right_2_no_padding(batch_td)
-            # step 3: add meta info
-            tu.assign_non_tensor(batch_td, calculate_entropy=True, compute_loss=False)
-            output = self.actor_rollout_wg.compute_log_prob(batch_td)
-            # gather output
-            entropy = tu.get(output, "entropy")
-            log_probs = tu.get(output, "log_probs")
-            routed_experts = tu.get(output, "routed_experts")
+        # TODO: remove step 1, 2, 4 after we make the whole training tensordict and padding free
+        # step 1: convert dataproto to tensordict.
+        batch_td = batch.to_tensordict()
+        # step 2: convert from padding to nopadding
+        batch_td = left_right_2_no_padding(batch_td)
+        # step 3: add meta info
+        calculate_sum_pi_squared = self.config.actor_rollout_ref.actor.get("calculate_sum_pi_squared", False)
+        tu.assign_non_tensor(
+            batch_td,
+            calculate_entropy=True,
+            calculate_sum_pi_squared=calculate_sum_pi_squared,
+            compute_loss=False,
+        )
+        output = self.actor_rollout_wg.compute_log_prob(batch_td)
+        # gather output
+        entropy = tu.get(output, "entropy")
+        log_probs = tu.get(output, "log_probs")
+        routed_experts = tu.get(output, "routed_experts")
+        sum_pi_squared = tu.get(output, "sum_pi_squared") if calculate_sum_pi_squared else None
 
-            old_log_prob_mfu = tu.get(output, "metrics")["mfu"]
-            # step 4. No padding to padding
-            entropy = no_padding_2_padding(entropy, batch_td)
-            log_probs = no_padding_2_padding(log_probs, batch_td)
-            # step 5: rebuild a tensordict and convert to dataproto
-            if routed_experts is not None:
-                old_log_prob = tu.get_tensordict(
-                    {"old_log_probs": log_probs.float(), "entropys": entropy.float(), "routed_experts": routed_experts}
-                )
-            else:
-                old_log_prob = tu.get_tensordict({"old_log_probs": log_probs.float(), "entropys": entropy.float()})
-            old_log_prob = DataProto.from_tensordict(old_log_prob)
-        else:
-            old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
-            old_log_prob_mfu = 0
+        old_log_prob_mfu = tu.get(output, "metrics")["mfu"]
+        # step 4. No padding to padding
+        entropy = no_padding_2_padding(entropy, batch_td)
+        log_probs = no_padding_2_padding(log_probs, batch_td)
+        if sum_pi_squared is not None:
+            sum_pi_squared = no_padding_2_padding(sum_pi_squared, batch_td)
+        # step 5: rebuild a tensordict and convert to dataproto
+        result = {"old_log_probs": log_probs.float(), "entropys": entropy.float()}
+        if routed_experts is not None:
+            result["routed_experts"] = routed_experts
+        if sum_pi_squared is not None:
+            result["sum_pi_squared"] = sum_pi_squared.float()
+        old_log_prob = tu.get_tensordict(result)
+        old_log_prob = DataProto.from_tensordict(old_log_prob)
         return old_log_prob, old_log_prob_mfu
 
     def _update_actor(self, batch: DataProto) -> DataProto:
@@ -1220,71 +1208,67 @@ class RayPPOTrainer:
         # TODO: Make "temperature" single source of truth from generation.
         batch.meta_info["temperature"] = rollout_config.temperature
         # update actor
-        if self.use_legacy_worker_impl == "disable":
-            batch_td = batch.to_tensordict()
-            # step 2: convert from padding to no-padding
-            batch_td = left_right_2_no_padding(batch_td)
-            calculate_entropy = self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
-            distillation_use_topk = (
-                self.distillation_config.distillation_loss.loss_settings.use_topk
-                if is_distillation_enabled(self.config.get("distillation"))
-                else False
-            )
-            ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
-            ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
-            ppo_epochs = self.config.actor_rollout_ref.actor.ppo_epochs
-            seed = self.config.actor_rollout_ref.actor.data_loader_seed
-            shuffle = self.config.actor_rollout_ref.actor.shuffle
-            tu.assign_non_tensor(
-                batch_td,
-                calculate_entropy=calculate_entropy,
-                distillation_use_topk=distillation_use_topk,
-                global_batch_size=ppo_mini_batch_size,
-                mini_batch_size=ppo_mini_batch_size,
-                epochs=ppo_epochs,
-                seed=seed,
-                dataloader_kwargs={"shuffle": shuffle},
-                compute_loss=True,
-            )
-            actor_output = self.actor_rollout_wg.update_actor(batch_td)
-            actor_output = tu.get(actor_output, "metrics")
-            actor_output = rename_dict(actor_output, "actor/")
-            # modify key name
-            actor_output["perf/mfu/actor"] = actor_output.pop("actor/mfu")
-            actor_output = DataProto.from_single_dict(data={}, meta_info={"metrics": actor_output})
-        else:
-            actor_output = self.actor_rollout_wg.update_actor(batch)
+        batch_td = batch.to_tensordict()
+        # step 2: convert from padding to no-padding
+        batch_td = left_right_2_no_padding(batch_td)
+        calculate_entropy = self.config.actor_rollout_ref.actor.calculate_entropy or (
+            self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
+        )
+        distillation_use_topk = (
+            self.distillation_config.distillation_loss.loss_settings.use_topk
+            if is_distillation_enabled(self.config.get("distillation"))
+            else False
+        )
+        ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
+        ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+        ppo_epochs = self.config.actor_rollout_ref.actor.ppo_epochs
+        seed = self.config.actor_rollout_ref.actor.data_loader_seed
+        shuffle = self.config.actor_rollout_ref.actor.shuffle
+        tu.assign_non_tensor(
+            batch_td,
+            calculate_entropy=calculate_entropy,
+            distillation_use_topk=distillation_use_topk,
+            global_batch_size=ppo_mini_batch_size,
+            mini_batch_size=ppo_mini_batch_size,
+            epochs=ppo_epochs,
+            seed=seed,
+            dataloader_kwargs={"shuffle": shuffle},
+            compute_loss=True,
+        )
+        actor_output = self.actor_rollout_wg.update_actor(batch_td)
+        actor_output = tu.get(actor_output, "metrics")
+        actor_output = rename_dict(actor_output, "actor/")
+        # modify key name
+        actor_output["perf/mfu/actor"] = actor_output.pop("actor/mfu")
+        actor_output = DataProto.from_single_dict(data={}, meta_info={"metrics": actor_output})
 
         return actor_output
 
     def _update_critic(self, batch: DataProto) -> DataProto:
-        if self.use_legacy_worker_impl == "disable":
-            batch_td = batch.to_tensordict()
-            # step 2: convert from padding to no-padding
-            batch_td = left_right_2_no_padding(batch_td)
-            ppo_mini_batch_size = self.config.critic.ppo_mini_batch_size
-            ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
-            ppo_epochs = self.config.critic.ppo_epochs
-            seed = self.config.critic.data_loader_seed
-            shuffle = self.config.critic.shuffle
-            tu.assign_non_tensor(
-                batch_td,
-                global_batch_size=ppo_mini_batch_size,
-                mini_batch_size=ppo_mini_batch_size,
-                epochs=ppo_epochs,
-                seed=seed,
-                dataloader_kwargs={"shuffle": shuffle},
-            )
+        batch_td = batch.to_tensordict()
+        # step 2: convert from padding to no-padding
+        batch_td = left_right_2_no_padding(batch_td)
+        ppo_mini_batch_size = self.config.critic.ppo_mini_batch_size
+        ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+        ppo_epochs = self.config.critic.ppo_epochs
+        seed = self.config.critic.data_loader_seed
+        shuffle = self.config.critic.shuffle
+        tu.assign_non_tensor(
+            batch_td,
+            global_batch_size=ppo_mini_batch_size,
+            mini_batch_size=ppo_mini_batch_size,
+            epochs=ppo_epochs,
+            seed=seed,
+            dataloader_kwargs={"shuffle": shuffle},
+        )
 
-            output = self.critic_wg.train_mini_batch(batch_td)
-            output = output.get()
-            output = tu.get(output, "metrics")
-            output = rename_dict(output, "critic/")
-            # modify key name
-            output["perf/mfu/critic"] = output.pop("critic/mfu")
-            critic_output = DataProto.from_single_dict(data={}, meta_info={"metrics": output})
-        else:
-            critic_output = self.critic_wg.update_critic(batch)
+        output = self.critic_wg.train_mini_batch(batch_td)
+        output = output.get()
+        output = tu.get(output, "metrics")
+        output = rename_dict(output, "critic/")
+        # modify key name
+        output["perf/mfu/critic"] = output.pop("critic/mfu")
+        critic_output = DataProto.from_single_dict(data={}, meta_info={"metrics": output})
         return critic_output
 
     def fit(self):
@@ -1368,9 +1352,8 @@ class RayPPOTrainer:
 
                 # pass global_steps to trace
                 gen_batch.meta_info["global_steps"] = self.global_steps
-                gen_batch_output = gen_batch.repeat(
-                    repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True
-                )
+                rollout_n = self.config.actor_rollout_ref.rollout.n
+                gen_batch_output = gen_batch.repeat(repeat_times=rollout_n, interleave=True)
                 # Inject prefix_segments prior for prefix-tree MAGI attention.
                 # DataProto.repeat() already propagates existing prefix_segments entries
                 # (np.repeat interleaves them correctly).  This fallback handles datasets
@@ -1395,55 +1378,55 @@ class RayPPOTrainer:
                         dtype=object,
                     )
 
+                if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+                    # NOTE: REMAX needs one sampled rollout plus one greedy baseline per prompt.
+                    # Keep them in a single agent-loop/vLLM request to avoid sending a second
+                    # rollout after replicas have been put to sleep, which can leave async vLLM
+                    # engines in an invalid state for multi-turn agent workloads.
+                    gen_batch_output.non_tensor_batch["__do_sample__"] = np.ones(len(gen_batch_output), dtype=bool)
+                    gen_baseline_batch = gen_batch.slice(0, None)
+                    gen_baseline_batch.non_tensor_batch["__do_sample__"] = np.zeros(len(gen_baseline_batch), dtype=bool)
+                    combined_gen_batch = DataProto.concat([gen_batch_output, gen_baseline_batch])
+                    num_sampled_prompts = len(gen_batch_output)
+                else:
+                    combined_gen_batch = gen_batch_output
+                    num_sampled_prompts = len(gen_batch_output)
+
                 is_last_step = self.global_steps >= self.total_training_steps
                 with marked_timer("step", timing_raw):
                     # generate a batch
                     with marked_timer("gen", timing_raw, color="red"):
                         if curr_step_profile:
-                            self.async_rollout_manager.start_profile()
-                        gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
+                            self.llm_server_manager.start_profile()
+                        combined_gen_output = self.async_rollout_manager.generate_sequences(combined_gen_batch)
                         self.checkpoint_manager.sleep_replicas()
                         if curr_step_profile:
-                            self.async_rollout_manager.stop_profile()
+                            self.llm_server_manager.stop_profile()
 
-                        timing_raw.update(gen_batch_output.meta_info["timing"])
-                        gen_batch_output.meta_info.pop("timing", None)
+                        timing_raw.update(combined_gen_output.meta_info["timing"])
+                        combined_gen_output.meta_info.pop("timing", None)
+
+                    gen_batch_output = combined_gen_output.slice(0, num_sampled_prompts)
+                    if "__do_sample__" in gen_batch_output.non_tensor_batch:
+                        gen_batch_output.pop(non_tensor_batch_keys=["__do_sample__"])
 
                     if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
-                        with marked_timer("gen_max", timing_raw, color="purple"):
-                            gen_baseline_batch = deepcopy(gen_batch)
-                            gen_baseline_batch.meta_info["do_sample"] = False
-                            if curr_step_profile:
-                                self.async_rollout_manager.start_profile()
-                            gen_baseline_output = self.async_rollout_manager.generate_sequences(gen_baseline_batch)
-                            self.checkpoint_manager.sleep_replicas()
-                            if curr_step_profile:
-                                self.async_rollout_manager.stop_profile()
-                            batch = batch.union(gen_baseline_output)
-                            # compute reward model score on batch
-                            rm_scores = None
-                            if self.use_rm and "rm_scores" not in batch.batch.keys():
-                                batch_reward = self._compute_reward_colocate(batch)
-                                batch = batch.union(batch_reward)
+                        gen_baseline_output = combined_gen_output.slice(num_sampled_prompts, None)
+                        if "__do_sample__" in gen_baseline_output.non_tensor_batch:
+                            gen_baseline_output.pop(non_tensor_batch_keys=["__do_sample__"])
 
-                            # Compute or extract reward for REMAX baseline
-                            reward_baseline_tensor = batch.batch["rm_scores"].sum(dim=-1)
+                        if self.use_rm and "rm_scores" not in gen_baseline_output.batch.keys():
+                            baseline_reward = self._compute_reward_colocate(gen_baseline_output)
+                            gen_baseline_output = gen_baseline_output.union(baseline_reward)
 
-                            keys_to_pop = set(gen_baseline_output.batch.keys())
-                            if rm_scores is not None:
-                                keys_to_pop.update(rm_scores.batch.keys())
-                            batch.pop(batch_keys=list(keys_to_pop))
+                        reward_baseline_tensor = gen_baseline_output.batch["rm_scores"].sum(dim=-1)
+                        batch.batch["reward_baselines"] = reward_baseline_tensor
 
-                            batch.batch["reward_baselines"] = reward_baseline_tensor
-
-                            del rm_scores, gen_baseline_batch, gen_baseline_output
+                        del gen_baseline_output
+                    del combined_gen_batch, combined_gen_output
                     # repeat to align with repeated responses in rollout
                     batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
                     batch = batch.union(gen_batch_output)
-                    if self._should_compute_teacher_colocate(batch):
-                        with marked_timer("teacher", timing_raw, color="cyan"):
-                            batch_teacher = self._compute_teacher_colocate(batch)
-                            batch = batch.union(batch_teacher)
 
                     if "response_mask" not in batch.batch.keys():
                         batch.batch["response_mask"] = compute_response_mask(batch)
@@ -1685,23 +1668,11 @@ class RayPPOTrainer:
                 metrics.update(compute_variance_proxy_metrics(batch=batch, gradient_norm=gradient_norm))
                 # Note: mismatch metrics (KL, PPL, etc.) are collected at line 1179 after advantage computation
 
-                # this is experimental and may be changed/removed in the future in favor of a general-purpose one
-                if isinstance(self.train_dataloader.sampler, AbstractCurriculumSampler):
-                    self.train_dataloader.sampler.update(batch=batch)
-
                 # TODO: make a canonical logger that supports various backend
                 logger.log(data=metrics, step=self.global_steps)
 
                 progress_bar.update(1)
                 self.global_steps += 1
-
-                if (
-                    hasattr(self.config.actor_rollout_ref.actor, "profiler")
-                    and self.config.actor_rollout_ref.actor.profiler.tool == "torch_memory"
-                ):
-                    self.actor_rollout_wg.dump_memory_snapshot(
-                        tag=f"post_update_step{self.global_steps}", sub_dir=f"step{self.global_steps}"
-                    )
 
                 if is_last_step:
                     if hasattr(self.actor_rollout_wg, "async_calls_finalize_fn_exec"):

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1365,6 +1365,7 @@ class RayPPOTrainer:
                     and "input_ids" in gen_batch_output.batch.keys()
                 ):
                     from verl.utils.prefix_tree_magi import build_prefix_segments_single_turn
+
                     _ids = gen_batch_output.batch["input_ids"]
                     _mask = gen_batch_output.batch.get("attention_mask", None)
                     gen_batch_output.non_tensor_batch["prefix_segments"] = np.array(

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -239,7 +239,11 @@ class SFTTrainer:
         dp_size = self.engine.get_data_parallel_size()
 
         self.train_sampler = DistributedSampler(
-            self.train_dataset, shuffle=self.config.data.get("shuffle", True), num_replicas=dp_size, rank=dp_rank, drop_last=True
+            self.train_dataset,
+            shuffle=self.config.data.get("shuffle", True),
+            num_replicas=dp_size,
+            rank=dp_rank,
+            drop_last=True,
         )
 
         self.global_batch_size = config.data.train_batch_size

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -185,8 +185,11 @@ class SFTTrainer:
         dp_size = 1
 
         self.train_sampler = DistributedSampler(
-            self.train_dataset, shuffle=self.config.data.get("shuffle", True),
-            num_replicas=dp_size, rank=dp_rank, drop_last=True
+            self.train_dataset,
+            shuffle=self.config.data.get("shuffle", True),
+            num_replicas=dp_size,
+            rank=dp_rank,
+            drop_last=True,
         )
 
         self.global_batch_size = config.data.train_batch_size

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -36,8 +36,8 @@ from verl.utils.chat_template import apply_chat_template, extract_system_prompt_
 from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.dataset.vision_utils import process_image, process_video
 from verl.utils.fs import copy_local_path_from_hdfs
-from verl.utils.py_functional import convert_nested_value_to_list_recursive
 from verl.utils.prefix_tree_magi import _hash_prefix as _hash_prefix_ids
+from verl.utils.py_functional import convert_nested_value_to_list_recursive
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -178,7 +178,9 @@ class MultiTurnSFTDataset(Dataset):
 
         # system prompt: <|im_start|>system\nYou are a helpful assistant.<|im_end|>\n
         # generation prompt: <|im_start|>assistant\n
-        self.system_prompt, self.generation_prompt = extract_system_prompt_and_generation(self.tokenizer)
+        self.system_prompt, self.generation_prompt = extract_system_prompt_and_generation(
+            self.tokenizer, **self.apply_chat_template_kwargs
+        )
 
     def __len__(self):
         return len(self.messages)

--- a/verl/utils/prefix_tree_dynamic.py
+++ b/verl/utils/prefix_tree_dynamic.py
@@ -1,0 +1,264 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2025-2026 The AReaL Authors (Ant Group, Tsinghua University, HKUST)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dynamic-trie prefix-tree builder.
+
+Token-by-token trie insertion supporting arbitrary tree depth. Detects the
+shared-prefix tree directly from input tokens; no rollout-side metadata
+required. Invoked by
+:func:`verl.utils.prefix_tree_magi.build_prefix_tree_micro_batch` when
+``dynamic_trie=True``.
+
+Algorithm originally derived from AReaL
+(https://github.com/inclusionAI/AReaL).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from torch import Tensor
+
+from verl.utils.prefix_tree_utils import TreeNode
+
+__all__ = [
+    "build_tree_dynamic",
+    # Lower-level helpers exposed for testing / benchmarking
+    "TrieNode",
+    "greedy_build_tries",
+    "convert_trie_to_tree_node",
+]
+
+
+# ============================================================================
+# Trie construction (token-by-token insertion)
+# ============================================================================
+
+
+@dataclass
+class TrieNode:
+    """Compressed-trie node (after `_compress` pass).
+
+    Each non-root node represents a contiguous run of tokens shared by the same
+    set of sequences. Root has ``start_idx == end_idx == -1`` and stores no
+    tokens — children are accessed via ``.children: dict[first_token, TrieNode]``.
+    """
+
+    tree_id: int
+    start_idx: int = -1
+    end_idx: int = -1
+    tokens: list[int] = field(default_factory=list)
+    sequence_ids: list[int] = field(default_factory=list)
+    children: dict[int, TrieNode] = field(default_factory=dict)
+    ancestors: list[TrieNode] = field(default_factory=list)
+    nodes: list[TrieNode] = field(default_factory=list)
+
+    @property
+    def is_root(self) -> bool:
+        return self.start_idx == -1 and self.end_idx == -1
+
+
+class _BuildNode:
+    """Internal — temporary uncompressed node used during insertion."""
+
+    __slots__ = ("tree_id", "token_id", "node_id", "children", "is_end", "sequence_ids")
+
+    def __init__(self, tree_id: int, token_id: int, node_id: int):
+        self.tree_id = tree_id
+        self.token_id = token_id
+        self.node_id = node_id
+        self.children: dict[int, _BuildNode] = {}
+        self.is_end = False
+        self.sequence_ids: list[int] = []
+
+
+def _count_additional_nodes(root: _BuildNode, sequence: list[int]) -> int:
+    current = root
+    for idx, token in enumerate(sequence):
+        child = current.children.get(token)
+        if child is None:
+            return len(sequence) - idx
+        current = child
+    return 0
+
+
+def _insert_sequence(
+    root: _BuildNode,
+    all_nodes: list[_BuildNode],
+    sequence: list[int],
+    tree_id: int,
+    sequence_id: int,
+) -> None:
+    current = root
+    for token in sequence:
+        if token not in current.children:
+            node_id = len(all_nodes)
+            current.children[token] = _BuildNode(tree_id, token, node_id)
+            all_nodes.append(current.children[token])
+        current.children[token].sequence_ids.append(sequence_id)
+        current = current.children[token]
+    current.is_end = True
+
+
+def _compress_trie(root: _BuildNode) -> TrieNode:
+    trie_root = TrieNode(tree_id=root.tree_id)
+
+    def _compress_chain(node: _BuildNode, ancestors: list[TrieNode]) -> TrieNode:
+        tokens: list[int] = []
+        current = node
+        start_id = node.node_id
+        while True:
+            tokens.append(current.token_id)
+            if len(current.children) != 1 or current.is_end:
+                break
+            next_child = next(iter(current.children.values()))
+            if current.sequence_ids != next_child.sequence_ids:
+                raise ValueError("Sequence IDs mismatch along chain")
+            if next_child.node_id != current.node_id + 1:
+                raise ValueError("Node IDs not consecutive along chain")
+            current = next_child
+
+        trie_node = TrieNode(
+            tree_id=root.tree_id,
+            start_idx=start_id,
+            end_idx=current.node_id,
+            tokens=tokens,
+            sequence_ids=current.sequence_ids.copy(),
+            ancestors=ancestors.copy(),
+        )
+        trie_root.nodes.append(trie_node)
+        if current.children:
+            for token, child in sorted(current.children.items()):
+                trie_node.children[token] = _compress_chain(child, ancestors + [trie_node])
+        return trie_node
+
+    if root.children:
+        for token, child in sorted(root.children.items()):
+            trie_root.children[token] = _compress_chain(child, [])
+    return trie_root
+
+
+def greedy_build_tries(
+    sequences: list[list[int]],
+    max_tokens_per_tree: int,
+) -> tuple[list[TrieNode], list[int]]:
+    """Token-by-token greedy trie packing across samples.
+
+    Args:
+        sequences: per-sample token lists.
+        max_tokens_per_tree: upper bound on uncompressed nodes per tree (set to
+            a huge value when you want a single forest).
+
+    Returns:
+        (tries, num_tokens_list) — list of compressed TrieNode roots + total
+        uncompressed nodes per tree.
+    """
+    forests: list[dict[str, Any]] = []
+    for seq_id, seq in enumerate(sequences):
+        inserted = False
+        for tree_id, tree in enumerate(forests):
+            additional = _count_additional_nodes(tree["root"], seq)
+            if tree["nodes"] + additional <= max_tokens_per_tree:
+                _insert_sequence(tree["root"], tree["all_nodes"], seq, tree_id, seq_id)
+                tree["nodes"] += additional
+                inserted = True
+                break
+        if inserted:
+            continue
+        if len(seq) > max_tokens_per_tree:
+            raise ValueError(f"Sequence length {len(seq)} exceeds max_tokens_per_tree {max_tokens_per_tree}")
+        new_tree_id = len(forests)
+        new_root = _BuildNode(new_tree_id, -1, -1)
+        all_nodes: list[_BuildNode] = []
+        _insert_sequence(new_root, all_nodes, seq, new_tree_id, seq_id)
+        forests.append({"root": new_root, "all_nodes": all_nodes, "nodes": len(seq)})
+
+    tries = [_compress_trie(f["root"]) for f in forests]
+    num_tokens_list = [f["nodes"] for f in forests]
+    return tries, num_tokens_list
+
+
+# ============================================================================
+# Trie → TreeNode conversion (arbitrary depth preserved)
+# ============================================================================
+
+
+def convert_trie_to_tree_node(
+    trie: TrieNode,
+) -> Optional[tuple[TreeNode, list[int]]]:
+    """Convert a compressed trie to ``(TreeNode, leaf_to_sample)`` consumed by
+    :func:`verl.utils.prefix_tree_utils.build_layout_from_tree_node`.
+
+    The trie root is a virtual placeholder with no tokens. We promote the
+    trie's only child as the TreeNode root so the downstream flex-spec
+    builder sees a non-zero root segment.
+
+    Returns ``None`` when there's no real sharing (single sample, no children,
+    or multi-forest case).
+
+    Returns ``(root, leaf_to_sample)`` where ``leaf_to_sample[i]`` is the
+    original sample index for the i-th leaf in DFS pre-order — matches the
+    contract expected by ``build_layout_from_tree_node``.
+    """
+    if not trie.children:
+        return None
+    if len(trie.children) > 1:
+        return None
+
+    leaf_to_sample: list[int] = []
+
+    def _convert(trie_node: TrieNode) -> TreeNode:
+        segment_len = len(trie_node.tokens)
+        children: list[TreeNode] = [_convert(child) for _tok, child in sorted(trie_node.children.items())]
+        node = TreeNode(segment_len=segment_len, children=children)
+        if not children:
+            assert len(trie_node.sequence_ids) == 1, (
+                f"Trie leaf should belong to exactly 1 sample, got {trie_node.sequence_ids}"
+            )
+            leaf_to_sample.append(trie_node.sequence_ids[0])
+        return node
+
+    only_child = next(iter(trie.children.values()))
+    root = _convert(only_child)
+    if not root.children:
+        return None
+    return root, leaf_to_sample
+
+
+# ============================================================================
+# Detection entry: build_tree_dynamic
+# ============================================================================
+
+
+def build_tree_dynamic(samples: list[Tensor]) -> Optional[tuple[TreeNode, list[int]]]:
+    """Token-by-token trie detection. Returns ``(TreeNode, leaf_to_sample)`` or None.
+
+    Builds a compressed trie of the input samples, then converts it to the
+    canonical ``TreeNode`` representation consumed by
+    :func:`verl.utils.prefix_tree_utils.build_layout_from_tree_node`.
+
+    ``leaf_to_sample[i]`` gives the original sample index for the i-th leaf in
+    DFS pre-order. Returns ``None`` when there's no shared prefix (empty input,
+    single sample, or multi-forest case).
+    """
+    if not samples:
+        return None
+    sequences = [t.tolist() for t in samples]
+    max_tokens_per_tree = sum(len(s) for s in sequences) * 10  # one forest
+    tries, _ = greedy_build_tries(sequences, max_tokens_per_tree=max_tokens_per_tree)
+    if not tries or len(tries) > 1:
+        return None
+    return convert_trie_to_tree_node(tries[0])

--- a/verl/utils/prefix_tree_hash_based.py
+++ b/verl/utils/prefix_tree_hash_based.py
@@ -1,0 +1,218 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hash-based prefix detection.
+
+Counterpart to :func:`verl.utils.prefix_tree_dynamic.build_tree_dynamic` —
+both produce the same ``(TreeNode, leaf_to_sample)`` contract consumed by
+:func:`verl.utils.prefix_tree_utils.build_layout_from_tree_node`.
+
+Two-stage detection:
+  1. Root prefix length — from per-turn hashes (``prefix_segments_batch``)
+     when available, else from a token-level LCP scan.
+  2. Multi-level (depth-2) — when ``prefix_segments_batch`` is provided and
+     the batch has ≥2 groups of ≥2 samples sharing a second-turn hash,
+     produce a depth-2 tree; otherwise fall back to single-level (root +
+     per-sample leaves).
+
+Supports depth-1 and depth-2 only. For arbitrary-depth trees, use
+``build_tree_dynamic``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Optional
+
+from torch import Tensor
+
+from verl.utils.prefix_tree_utils import TreeNode, longest_common_prefix_length
+
+__all__ = [
+    "_hash_prefix",
+    "build_prefix_segments_single_turn",
+    "build_tree_hash_based",
+]
+
+
+def _hash_prefix(token_ids_flat: Tensor) -> int:
+    """128-bit hash of a 1-D token-id tensor (full cumulative prefix).
+
+    Uses xxhash when available (faster); falls back to hashlib.md5.
+    The 128-bit width makes accidental collision negligible in practice.
+    """
+    raw = token_ids_flat.numpy().tobytes()
+    try:
+        import xxhash  # type: ignore[import]
+
+        return xxhash.xxh128_intdigest(raw)
+    except ImportError:
+        import hashlib
+
+        return int.from_bytes(hashlib.md5(raw).digest(), "little")
+
+
+def build_prefix_segments_single_turn(
+    input_ids: Tensor,
+    attention_mask: Optional[Tensor] = None,
+) -> list[tuple[int, int]]:
+    """Build a single-entry prefix_segments list for one sample.
+
+    Used by RL trainers when per-sub-turn boundaries are unavailable — the
+    single entry covers the entire real (non-pad) prompt and lets the hash
+    path detect the prompt as a shared root prefix across GRPO-style
+    rollouts.
+
+    Args:
+        input_ids: 1-D or 2-D (1, seq_len) token tensor.
+        attention_mask: Optional 1-D or 2-D mask; when provided, only the
+            tokens where mask==1 are considered (strips padding).
+
+    Returns:
+        ``[(hash, prompt_len)]`` — a one-element prefix_segments list.
+    """
+    ids = input_ids.flatten()
+    if attention_mask is not None:
+        mask = attention_mask.flatten().bool()
+        ids = ids[mask]
+    h = _hash_prefix(ids.cpu())
+    return [(h, int(ids.numel()))]
+
+
+def build_tree_hash_based(
+    samples: list[Tensor],
+    prefix_segments_batch: Optional[list[list[tuple[int, int]]]] = None,
+) -> Optional[tuple[TreeNode, list[int]]]:
+    """Hash-based prefix detection. Returns ``(TreeNode, leaf_to_sample)`` or None.
+
+    ``leaf_to_sample[i]`` gives the original sample index for the i-th leaf in
+    DFS pre-order. Returns ``None`` when no shared prefix exists.
+    """
+    import os as _os
+
+    n = len(samples)
+    if n == 0:
+        return None
+
+    if prefix_segments_batch is not None and len(prefix_segments_batch) == n:
+        prefix_len = _resolve_prefix_len_from_segments(prefix_segments_batch)
+        if _os.environ.get("DEBUG_PREFIX_LEN") == "1":
+            scan_len = longest_common_prefix_length(samples)
+            T = samples[0].shape[0] if samples else 0
+            print(
+                f"[PREFIX_LEN] seg_len={prefix_len} scan_len={scan_len} T={T} "
+                f"n_segs={[len(s) for s in prefix_segments_batch]}",
+                flush=True,
+            )
+    else:
+        prefix_len = longest_common_prefix_length(samples)
+
+    if prefix_len == 0:
+        return None
+
+    if prefix_segments_batch is not None:
+        actual_root_len = longest_common_prefix_length(samples)
+        if actual_root_len > 0:
+            multilevel = _resolve_multilevel_tree(samples, prefix_segments_batch, actual_root_len)
+            if multilevel is not None:
+                root_len, children_info = multilevel  # [(idxs, group_TreeNode), ...]
+                root = TreeNode(segment_len=root_len, children=[g for _, g in children_info])
+                leaf_to_sample = [int(idx) for idxs, _ in children_info for idx in idxs]
+                return root, leaf_to_sample
+
+    # Single-level fallback: root + per-sample leaves (one leaf per sample).
+    leaves = [TreeNode(segment_len=int(t.shape[0]) - prefix_len) for t in samples]
+    root = TreeNode(segment_len=prefix_len, children=leaves)
+    return root, list(range(n))
+
+
+def _resolve_prefix_len_from_segments(
+    prefix_segments_batch: list[list[tuple[int, int]]],
+) -> int:
+    """Return the longest shared-prefix length derivable from per-sample segment lists.
+
+    Each element of ``prefix_segments_batch`` is a list of
+    ``(hash, cumulative_len)`` pairs produced by the dataset at load time. Two
+    samples share turn k when all samples have the same per-turn hash at
+    position k.
+
+    Walks turn-by-turn and stops at the first turn where hashes diverge;
+    returns the cumulative_len from sample 0 at the last shared turn (0 if
+    none).
+
+    Compares only hashes (not cum_len) because tokenization boundary effects
+    can shift cum_len slightly between samples even for identical turns.
+    """
+    n = len(prefix_segments_batch)
+    if n == 0:
+        return 0
+
+    min_turns = min(len(segs) for segs in prefix_segments_batch)
+    if min_turns == 0:
+        return 0
+
+    best = 0
+    for turn_idx in range(min_turns):
+        h0 = prefix_segments_batch[0][turn_idx][0]
+        if all(prefix_segments_batch[i][turn_idx][0] == h0 for i in range(1, n)):
+            best = prefix_segments_batch[0][turn_idx][1]
+        else:
+            break
+    return best
+
+
+def _resolve_multilevel_tree(
+    tokens_by_sample: list,
+    prefix_segments_batch: list[list[tuple[int, int]]],
+    root_prefix_len: int,
+) -> Optional[tuple[int, list[tuple[list[int], TreeNode]]]]:
+    """Detect a depth-2 tree from prefix_segments. Returns ``(root_len, children_info)`` or None.
+
+    Groups samples by their first post-root segment hash. If ≥2 groups each
+    have ≥2 samples, a depth-2 tree exists and we return
+    ``(root_len, [(sample_idxs, group_TreeNode), ...])``.
+    """
+    n = len(tokens_by_sample)
+    if prefix_segments_batch is None or n < 4:
+        return None
+
+    # Group samples by the hash of their first post-root turn (O(batch×turns)).
+    groups: dict[int, list[int]] = defaultdict(list)
+    for i, segs in enumerate(prefix_segments_batch):
+        next_seg = next((s for s in segs if s[1] > root_prefix_len), None)
+        if next_seg is None:
+            return None
+        groups[next_seg[0]].append(i)
+
+    # Need ≥2 groups each with ≥2 samples for multi-level to be worthwhile.
+    useful = [(h, idxs) for h, idxs in groups.items() if len(idxs) >= 2]
+    if len(useful) < 2:
+        return None
+
+    # Use token scan (not segment hashes) to get exact turn2 shared prefix length
+    # per group; segment hashes can mis-align due to chat-template boundary effects.
+    children = []
+    for _h, idxs in useful:
+        group_tokens = [tokens_by_sample[i] for i in idxs]
+        suffixes = [t[root_prefix_len:] for t in group_tokens]
+        shared_suffix_len = longest_common_prefix_length(suffixes)
+        if shared_suffix_len <= 0:
+            return None
+        group_turn2_len = shared_suffix_len
+        leaves = [TreeNode(int(tokens_by_sample[i].shape[0]) - root_prefix_len - group_turn2_len, []) for i in idxs]
+        if any(leaf.segment_len <= 0 for leaf in leaves):
+            return None
+        children.append((idxs, TreeNode(group_turn2_len, leaves)))
+
+    return (root_prefix_len, children)

--- a/verl/utils/prefix_tree_magi.py
+++ b/verl/utils/prefix_tree_magi.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 """Prefix-tree + MAGI utilities for verl SFT training.
 
-Builds a MAGI attention key once per micro-batch from shared-prefix token
-sequences, and provides helpers to restore flat outputs back to per-sample
-NestedTensor form for downstream loss computation.
+Dispatches a micro-batch through either the hash-based
+(:mod:`verl.utils.prefix_tree_hash_based`) or dynamic-trie
+(:mod:`verl.utils.prefix_tree_dynamic`) detection path, materialises a flat
+layout via :func:`verl.utils.prefix_tree_utils.build_layout_from_tree_node`,
+and builds a MAGI / flex attention key for the result.
 
 Usage (inside gptmodel_forward_model_engine):
 
@@ -39,6 +41,12 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.nested._internal.nested_tensor import NestedTensor
+
+from verl.utils.prefix_tree_hash_based import (
+    _hash_prefix,  # noqa: F401  re-exported for backwards-compat callers
+    build_prefix_segments_single_turn,  # noqa: F401  re-exported for backwards-compat callers
+    build_tree_hash_based,
+)
 
 
 @dataclass
@@ -92,6 +100,21 @@ class PrefixTreeMagiBatch:
             self.local_flat_loss_mask = self.flat_loss_mask
 
 
+def _unpack_nested_to_list(x) -> Optional[list[Tensor]]:
+    """Unpack a NestedTensor into a list of 1-D tensors, one per sample."""
+    if x is None:
+        return None
+    offsets = x.offsets()
+    lengths = offsets.diff().tolist()
+    vals = x.values()
+    out: list[Tensor] = []
+    pos = 0
+    for length in lengths:
+        out.append(vals[pos : pos + int(length)])
+        pos += int(length)
+    return out
+
+
 def build_prefix_tree_micro_batch(
     model,
     input_ids: NestedTensor,
@@ -101,11 +124,22 @@ def build_prefix_tree_micro_batch(
     attention_type: str = "flex",
     tp_size: int = 1,
     cp_size: int = 1,
+    dynamic_trie: bool = False,
 ) -> Optional[PrefixTreeMagiBatch]:
     """Build a PrefixTreeMagiBatch from a micro-batch of NestedTensor sequences.
 
-    Returns None when there is no shared prefix (prefix_len == 0), signalling
-    the caller to fall back to the standard attention path.
+    Two detection paths, selected by ``dynamic_trie``:
+
+      - ``dynamic_trie=False`` (default): hash-based fast path. Uses
+        ``prefix_segments_batch`` (per-sample turn-level hashes) when
+        provided, otherwise falls back to a token-level LCP scan. Supports
+        depth-1 and depth-2 tree shapes only.
+      - ``dynamic_trie=True``: token-by-token trie insertion. Detects
+        arbitrary-depth shared-prefix trees directly from the token
+        sequences. ``prefix_segments_batch`` is ignored on this path.
+
+    Returns None when there is no shared prefix, signalling the caller to
+    fall back to the standard attention path.
 
     Args:
         model: Megatron model (used to read num_heads / head_dim from config).
@@ -114,154 +148,53 @@ def build_prefix_tree_micro_batch(
         position_ids: Optional NestedTensor matching input_ids shape.
             When None, default RoPE-compatible position IDs are generated.
         prefix_segments_batch: Optional per-sample prior knowledge injected by
-            the dataset or trainer.  Each element is a list of
-            ``(hash, cumulative_len)`` pairs (one per sub-turn) produced at
-            data-load time.  When provided, prefix detection skips the O(batch ×
-            seqlen) token comparison and uses the O(batch × turns) hash lookup
-            instead.  Falls back to the scan when None or when no shared entry
-            is found.
+            the dataset or trainer (hash-path only). See
+            :func:`verl.utils.prefix_tree_hash_based.build_tree_hash_based`
+            for the expected format. Ignored when ``dynamic_trie=True``.
+        attention_type: ``"flex"`` or ``"magi"``.
+        tp_size / cp_size: Tensor / context parallel world sizes (for
+            SP-divisibility padding).
+        dynamic_trie: when True, dispatch to the trie path in
+            :mod:`verl.utils.prefix_tree_dynamic`. Default False.
 
     Returns:
         PrefixTreeMagiBatch or None.
     """
 
-    from verl.utils.prefix_tree_utils import (
-        build_prefix_tree_params,
-        longest_common_prefix_length,
+    from verl.utils.prefix_tree_utils import build_layout_from_tree_node
+
+    samples = _unpack_nested_to_list(input_ids)
+    if not samples:
+        return None
+    loss_masks_by_sample = _unpack_nested_to_list(loss_mask)
+    position_ids_by_sample = _unpack_nested_to_list(position_ids)
+
+    if dynamic_trie:
+        from verl.utils.prefix_tree_dynamic import build_tree_dynamic
+
+        result = build_tree_dynamic(samples)
+    else:
+        result = build_tree_hash_based(samples, prefix_segments_batch=prefix_segments_batch)
+
+    if result is None:
+        return None
+    tree_root, leaf_to_sample = result
+
+    params = build_layout_from_tree_node(
+        samples,
+        tree_root,
+        leaf_to_sample,
+        loss_masks_by_sample=loss_masks_by_sample,
+        position_ids_by_sample=position_ids_by_sample,
     )
 
-    # Unpack NestedTensor into a list of 1-D CPU tensors for prefix detection
-    offsets = input_ids.offsets()  # (batch_size+1,)
-    lengths = offsets.diff().tolist()
-    flat_vals = input_ids.values()  # (total_nnz,)
-
-    tokens_by_sample: list[Tensor] = []
-    pos = 0
-    for length in lengths:
-        tokens_by_sample.append(flat_vals[pos : pos + int(length)])
-        pos += int(length)
-
-    # Fast path: use injected prior knowledge when available.
-    import os as _os
-
-    if prefix_segments_batch is not None and len(prefix_segments_batch) == len(tokens_by_sample):
-        prefix_len = _resolve_prefix_len_from_segments(prefix_segments_batch)
-        if _os.environ.get("DEBUG_PREFIX_LEN") == "1":
-            scan_len = longest_common_prefix_length(tokens_by_sample)
-            T = tokens_by_sample[0].shape[0] if tokens_by_sample else 0
-            print(
-                f"[PREFIX_LEN] seg_len={prefix_len} scan_len={scan_len} T={T} "
-                f"n_segs={[len(s) for s in prefix_segments_batch]}",
-                flush=True,
-            )
-    else:
-        prefix_len = longest_common_prefix_length(tokens_by_sample)
-
-    if prefix_len == 0:
-        return None
-
-    # Optionally unpack loss_mask and position_ids per sample
-    loss_masks_by_sample: Optional[list[Tensor]] = None
-    if loss_mask is not None:
-        lm_vals = loss_mask.values()
-        lm_offsets = loss_mask.offsets()
-        lm_lengths = lm_offsets.diff().tolist()
-        loss_masks_by_sample = []
-        pos = 0
-        for length in lm_lengths:
-            loss_masks_by_sample.append(lm_vals[pos : pos + int(length)])
-            pos += int(length)
-
-    position_ids_by_sample: Optional[list[Tensor]] = None
-    if position_ids is not None:
-        pid_vals = position_ids.values()
-        pid_offsets = position_ids.offsets()
-        pid_lengths = pid_offsets.diff().tolist()
-        position_ids_by_sample = []
-        pos = 0
-        for length in pid_lengths:
-            position_ids_by_sample.append(pid_vals[pos : pos + int(length)])
-            pos += int(length)
-
-    # Try multi-level tree if prefix_segments are available.
-    # Use token-scan root_len (not segment-based) for correct boundary alignment.
-    multilevel_result = None
-    if prefix_segments_batch is not None:
-        actual_root_len = longest_common_prefix_length(tokens_by_sample)
-        if actual_root_len > 0:
-            multilevel_result = _resolve_multilevel_tree(tokens_by_sample, prefix_segments_batch, actual_root_len)
-
-    if multilevel_result is not None:
-        root_len, children_info = multilevel_result
-        params = _build_multilevel_prefix_tree_params(
-            tokens_by_sample,
-            root_len,
-            children_info,
-            loss_masks_by_sample=loss_masks_by_sample,
-            position_ids_by_sample=position_ids_by_sample,
-        )
-    else:
-        params = build_prefix_tree_params(
-            tokens_by_sample,
-            prefix_len=prefix_len,
-            loss_masks_by_sample=loss_masks_by_sample,
-            position_ids_by_sample=position_ids_by_sample,
-        )
-
-    # Sequence parallel (TP>1) requires total_tokens % align_size == 0.
-    # When CP>1, FA3 uses align_size = tp_size * cp_size * 2 (interleaved CP chunks).
-    # We must match this so MAGI and FA3 process identical token counts.
-    real_tokens = params.flat_tokens.shape[0]
-    if tp_size > 1:
-        align_size = (tp_size * cp_size * 2) if cp_size > 1 else tp_size
-        total = real_tokens
-        pad_len = (align_size - total % align_size) % align_size
-        if pad_len > 0:
-            import torch as _torch
-
-            params.flat_tokens = _torch.cat([params.flat_tokens, params.flat_tokens.new_zeros(pad_len)])
-            params.flat_position_ids = _torch.cat(
-                [params.flat_position_ids, params.flat_position_ids.new_zeros(pad_len)]
-            )
-            if params.flat_loss_mask is not None:
-                params.flat_loss_mask = _torch.cat([params.flat_loss_mask, params.flat_loss_mask.new_zeros(pad_len)])
-            params.total_seqlen_q += pad_len
-            params.total_seqlen_k += pad_len
-            # Do NOT add rectangles for padding tokens — they are stripped before loss.
-            # MAGI assigns zero attention weight to out-of-range positions automatically.
-
-    # Build attention key — only the requested type
-    if attention_type == "magi":
-        magi_key = _build_magi_key(model, params)
-        flex_key = None
-    else:  # flex (default)
-        device = params.flat_tokens.device
-        flex_key = _build_flex_key(params, device)
-        magi_key = None
-
-    # Note: CP dispatch at embedding level (dispatch before model, undispatch after)
-    # is the correct MAGI integration pattern but requires wrapping the full model
-    # forward including FFN layers. This is a TODO for proper CP support.
-    # For now, local_* == flat_* and dispatch/undispatch remain inside _magi_attn_forward.
-    local_flat_tokens = params.flat_tokens
-    local_flat_position_ids = params.flat_position_ids
-    local_flat_loss_mask = params.flat_loss_mask
-
-    return PrefixTreeMagiBatch(
-        flat_input_ids=params.flat_tokens,
-        flat_position_ids=params.flat_position_ids,
-        flat_loss_mask=params.flat_loss_mask,
-        magi_key=magi_key,
-        flex_key=flex_key,
-        leaf_to_sample=params.leaf_to_sample,
-        leaf_ranges=params.leaf_ranges,
-        prefix_range=params.prefix_range,
-        original_batch_size=params.num_samples,
-        real_tokens=real_tokens,
-        leaf_ancestor_ranges=getattr(params, "_leaf_ancestor_ranges", None),
-        local_flat_input_ids=local_flat_tokens,
-        local_flat_position_ids=local_flat_position_ids,
-        local_flat_loss_mask=local_flat_loss_mask,
+    return _finalize_prefix_tree_batch(
+        params,
+        model=model,
+        num_samples=len(samples),
+        attention_type=attention_type,
+        tp_size=tp_size,
+        cp_size=cp_size,
     )
 
 
@@ -271,8 +204,8 @@ def restore_flat_to_nested(
 ) -> NestedTensor:
     """Restore a flat (total_tokens, ...) tensor to a per-sample NestedTensor.
 
-    Each sample's view is ``[prefix_tokens || leaf_tokens]`` concatenated,
-    matching the original per-sample sequence length.
+    Each sample's view is ``[prefix_tokens || ancestor_tokens... || leaf_tokens]``
+    concatenated, matching the original per-sample sequence length.
 
     Args:
         flat_tensor: Tensor with first dimension == total_tokens.
@@ -284,8 +217,6 @@ def restore_flat_to_nested(
     prefix_start, prefix_end = pt_batch.prefix_range
     prefix_slice = flat_tensor[prefix_start:prefix_end]
 
-    # Reconstruct per-sample tensors in original sample order
-    # leaf_to_sample gives the original sample index for each leaf
     n = pt_batch.original_batch_size
     sample_tensors: list[Optional[Tensor]] = [None] * n
 
@@ -293,7 +224,6 @@ def restore_flat_to_nested(
         leaf_start, leaf_end = pt_batch.leaf_ranges[leaf_idx]
         leaf_slice = flat_tensor[leaf_start:leaf_end]
         if pt_batch.leaf_ancestor_ranges is not None:
-            # Multilevel: concatenate all ancestor ranges + leaf
             parts = [flat_tensor[s:e] for s, e in pt_batch.leaf_ancestor_ranges[leaf_idx]]
             parts.append(leaf_slice)
             sample_tensors[sample_idx] = torch.cat(parts, dim=0)
@@ -313,294 +243,58 @@ def restore_flat_to_nested(
 # ---------------------------------------------------------------------------
 
 
-def _hash_prefix(token_ids_flat: Tensor) -> int:
-    """128-bit hash of a 1-D token-id tensor (full cumulative prefix).
+def _finalize_prefix_tree_batch(
+    params,
+    model,
+    num_samples: int,
+    attention_type: str = "flex",
+    tp_size: int = 1,
+    cp_size: int = 1,
+) -> PrefixTreeMagiBatch:
+    """Common downstream step for both detection paths.
 
-    Uses xxhash when available (faster); falls back to hashlib.md5.
-    The 128-bit width makes accidental collision negligible in practice.
+    Pads to TP/CP divisibility, builds the requested attention key, and wraps
+    the result into a :class:`PrefixTreeMagiBatch`. Padding tokens are not
+    added to the attention rectangles — they are stripped before loss, and
+    MAGI assigns zero attention weight to out-of-range positions.
     """
-    raw = token_ids_flat.numpy().tobytes()
-    try:
-        import xxhash  # type: ignore[import]
+    real_tokens = params.flat_tokens.shape[0]
+    if tp_size > 1:
+        align_size = (tp_size * cp_size * 2) if cp_size > 1 else tp_size
+        pad_len = (align_size - real_tokens % align_size) % align_size
+        if pad_len > 0:
+            params.flat_tokens = torch.cat([params.flat_tokens, params.flat_tokens.new_zeros(pad_len)])
+            params.flat_position_ids = torch.cat(
+                [params.flat_position_ids, params.flat_position_ids.new_zeros(pad_len)]
+            )
+            if params.flat_loss_mask is not None:
+                params.flat_loss_mask = torch.cat([params.flat_loss_mask, params.flat_loss_mask.new_zeros(pad_len)])
+            params.total_seqlen_q += pad_len
+            params.total_seqlen_k += pad_len
 
-        return xxhash.xxh128_intdigest(raw)
-    except ImportError:
-        import hashlib
+    if attention_type == "magi":
+        magi_key = _build_magi_key(model, params)
+        flex_key = None
+    else:
+        flex_key = _build_flex_key(params, params.flat_tokens.device)
+        magi_key = None
 
-        return int.from_bytes(hashlib.md5(raw).digest(), "little")
-
-
-def _resolve_prefix_len_from_segments(
-    prefix_segments_batch: list[list[tuple[int, int]]],
-) -> int:
-    """Return the longest shared-prefix length derivable from per-sample segment lists.
-
-    Each element of *prefix_segments_batch* is a list of ``(hash, cumulative_len)``
-    pairs produced by the dataset at load time.  Two samples share turn k when all
-    samples have the same per-turn hash at position k.
-
-    Algorithm: walk turn-by-turn; stop at the first turn where hashes diverge.
-    Return the cumulative_len from sample 0 at the last shared turn (0 if none).
-
-    Using only hashes (not cum_len) for comparison because tokenization boundary
-    effects can shift cum_len slightly between samples even for identical turns.
-    """
-    n = len(prefix_segments_batch)
-    if n == 0:
-        return 0
-
-    # Find the minimum number of turns across all samples
-    min_turns = min(len(segs) for segs in prefix_segments_batch)
-    if min_turns == 0:
-        return 0
-
-    best = 0
-    for turn_idx in range(min_turns):
-        # Check if all samples have the same hash at this turn position
-        h0 = prefix_segments_batch[0][turn_idx][0]
-        if all(prefix_segments_batch[i][turn_idx][0] == h0 for i in range(1, n)):
-            # All match — use cum_len from sample 0 as the shared prefix boundary
-            best = prefix_segments_batch[0][turn_idx][1]
-        else:
-            break  # first divergence — stop
-
-    return best
-
-
-def _resolve_multilevel_tree(
-    tokens_by_sample: list,
-    prefix_segments_batch: list[list[tuple[int, int]]],
-    root_prefix_len: int,
-) -> Optional[object]:
-    """Detect a 2-level tree structure from prefix_segments and return a TreeNode, or None.
-
-    Groups samples by their first post-root segment hash. If ≥2 groups each
-    have ≥2 samples, a 2-level tree exists and we return a TreeNode root.
-    """
-    from collections import defaultdict
-
-    from verl.utils.prefix_tree_utils import TreeNode
-
-    n = len(tokens_by_sample)
-    if prefix_segments_batch is None or n < 4:
-        return None
-
-    # Group samples by the hash of their first post-root turn.
-    # With per-turn hashes in prefix_segments, use the hash directly
-    # (no token scan needed — O(batch×turns) instead of O(batch×seqlen)).
-    groups: dict[int, list[int]] = defaultdict(list)
-    for i, segs in enumerate(prefix_segments_batch):
-        # Find first segment whose cumlen > root_prefix_len — this is the first post-root turn
-        next_seg = next((s for s in segs if s[1] > root_prefix_len), None)
-        if next_seg is None:
-            return None  # no post-root turns
-        # Use per-turn hash directly (hash of just that turn's tokens)
-        groups[next_seg[0]].append(i)
-
-    # Need ≥2 groups each with ≥2 samples for multi-level to be worthwhile
-    useful = [(h, idxs) for h, idxs in groups.items() if len(idxs) >= 2]
-    if len(useful) < 2:
-        return None
-
-    # Use token scan (not segment hashes) to get exact turn2 shared prefix length per group.
-    # Segment hashes can mis-align due to chat-template boundary effects.
-    from verl.utils.prefix_tree_utils import longest_common_prefix_length
-
-    children = []
-    for _h, idxs in useful:
-        group_tokens = [tokens_by_sample[i] for i in idxs]
-        # scan from root_prefix_len onwards for shared content within this group
-        suffixes = [t[root_prefix_len:] for t in group_tokens]
-        shared_suffix_len = longest_common_prefix_length(suffixes)
-        if shared_suffix_len <= 0:
-            return None
-        group_turn2_len = shared_suffix_len
-        leaves = [TreeNode(int(tokens_by_sample[i].shape[0]) - root_prefix_len - group_turn2_len, []) for i in idxs]
-        if any(leaf.segment_len <= 0 for leaf in leaves):
-            return None
-        children.append((idxs, TreeNode(group_turn2_len, leaves)))
-
-    return (root_prefix_len, children)  # (root_len, [(sample_idxs, child_node), ...])
-
-
-def _build_multilevel_prefix_tree_params(
-    tokens_by_sample: list,
-    root_len: int,
-    children_info: list,  # [(sample_idxs, child_TreeNode), ...]
-    loss_masks_by_sample=None,
-    position_ids_by_sample=None,
-):
-    """Build PrefixTreeParams for a 2-level tree using build_multilevel_flex_spec."""
-    import torch
-
-    from verl.utils.prefix_tree_params import PrefixTreeParams
-    from verl.utils.prefix_tree_utils import TreeNode, build_multilevel_flex_spec
-
-    # Build TreeNode for flex_spec
-    tree_children = [child_node for _, child_node in children_info]
-    root_node = TreeNode(root_len, tree_children)
-
-    # Assign flat offsets via DFS pre-order (mirrors build_multilevel_flex_spec internals)
-    def _assign_offsets(node, start):
-        node._flat_start = start
-        node._flat_end = start + node.segment_len
-        cur = node._flat_end
-        for child in node.children:
-            cur = _assign_offsets(child, cur)
-        return cur
-
-    total_tokens = _assign_offsets(root_node, 0)
-
-    # Build flat token tensor: root + each child group + each leaf in DFS order
-    device = tokens_by_sample[0].device
-    flat_parts = [tokens_by_sample[0][:root_len]]  # shared root (same across all)
-
-    leaf_ranges = []
-    leaf_to_sample = []
-
-    def _flatten_node(node, sample_idxs_list, depth):
-        if node.is_leaf:
-            # leaf: take this sample's unique tail
-            sample_idx = sample_idxs_list[0]
-            tok = tokens_by_sample[sample_idx]
-            # tail = everything after root + all ancestor segments
-            tail_start = node._flat_start
-            tail_end = node._flat_end
-            # The sample tokens after root: tok[root_len:]
-            # We need to locate this leaf's content in the sample
-            # In DFS pre-order: node._flat_start = root_len + sum of prior sibling/parent segments
-            # The sample's tokens[root_len + parent_len : ] = leaf content
-            # parent_len = parent node's turn2 segment = child_node.segment_len for that branch
-            leaf_ranges.append((tail_start, tail_end))
-            leaf_to_sample.append(sample_idx)
-            return
-        # internal node: add this node's own tokens (shared by its group)
-        sample_idx = sample_idxs_list[0]
-        tok = tokens_by_sample[sample_idx]
-        # Compute where this node's tokens start in the original sample
-        # For root: sample[0:root_len]
-        # For depth-1 child: sample[root_len : root_len + child.segment_len]
-        if depth == 0:
-            content = tok[: node._flat_end]  # root tokens
-        else:
-            content = tok[root_len : root_len + node.segment_len]  # turn2 tokens
-        flat_parts.append(content)
-
-        # Recurse into children, distributing sample indices
-        leaf_idx = 0
-        for child in node.children:
-            n_leaves = _count_leaves(child)
-            _flatten_node(child, sample_idxs_list[leaf_idx : leaf_idx + n_leaves], depth + 1)
-            leaf_idx += n_leaves
-
-    def _count_leaves(node):
-        if node.is_leaf:
-            return 1
-        return sum(_count_leaves(c) for c in node.children)
-
-    # Flatten: root already added; now children in order
-    flat_parts = [tokens_by_sample[0][:root_len]]  # root (same for all samples)
-    leaf_ranges = []
-    leaf_to_sample = []
-    leaf_ancestor_ranges = []  # [(root_range, turn2_range), ...] per leaf
-
-    cur_offset = root_len
-    for child_idxs, child_node in children_info:
-        # Add turn2 tokens (from first sample of this group)
-        sample0 = child_idxs[0]
-        turn2_tokens = tokens_by_sample[sample0][root_len : root_len + child_node.segment_len]
-        flat_parts.append(turn2_tokens)
-        turn2_flat_start = cur_offset
-        cur_offset += child_node.segment_len
-        turn2_flat_range = (turn2_flat_start, cur_offset)
-
-        # Add each leaf
-        for leaf_node, sample_idx in zip(child_node.children, child_idxs, strict=False):
-            leaf_start = cur_offset
-            leaf_len = leaf_node.segment_len
-            leaf_tokens = tokens_by_sample[sample_idx][root_len + child_node.segment_len :]
-            assert leaf_tokens.shape[0] == leaf_len, f"leaf token mismatch: {leaf_tokens.shape[0]} != {leaf_len}"
-            flat_parts.append(leaf_tokens)
-            leaf_ranges.append((leaf_start, leaf_start + leaf_len))
-            leaf_to_sample.append(sample_idx)
-            leaf_ancestor_ranges.append([(0, root_len), turn2_flat_range])
-            cur_offset += leaf_len
-
-    flat_tokens = torch.cat(flat_parts)
-    assert flat_tokens.shape[0] == total_tokens, f"flat token count mismatch: {flat_tokens.shape[0]} != {total_tokens}"
-
-    # Build loss mask
-    flat_loss_mask = None
-    if loss_masks_by_sample is not None:
-        lm_parts = [loss_masks_by_sample[0][:root_len]]
-        for child_idxs, child_node in children_info:
-            sample0 = child_idxs[0]
-            lm_parts.append(loss_masks_by_sample[sample0][root_len : root_len + child_node.segment_len])
-            for leaf_node, sample_idx in zip(child_node.children, child_idxs, strict=False):
-                lm_parts.append(loss_masks_by_sample[sample_idx][root_len + child_node.segment_len :])
-        flat_loss_mask = torch.cat(lm_parts)
-
-    # Build position ids: root is 0..root_len-1, each turn2 starts at root_len,
-    # each leaf starts at root_len + turn2_len (matching the original sample positions)
-    # This matches what the model expects for RoPE: positions within each sample are
-    # relative to the start of that sample's content.
-    pid_parts = [torch.arange(root_len, device=device)]  # root: 0..root_len-1
-    for child_idxs, child_node in children_info:
-        # turn2 positions: root_len .. root_len + turn2_len - 1
-        pid_parts.append(torch.arange(root_len, root_len + child_node.segment_len, device=device))
-        for leaf_node, _sample_idx in zip(child_node.children, child_idxs, strict=False):
-            # leaf positions: root_len + turn2_len .. root_len + turn2_len + leaf_len - 1
-            leaf_start_pos = root_len + child_node.segment_len
-            pid_parts.append(torch.arange(leaf_start_pos, leaf_start_pos + leaf_node.segment_len, device=device))
-    flat_position_ids = torch.cat(pid_parts)
-
-    # Get attention rectangles from multilevel spec
-    q_ranges, k_ranges, mask_types = build_multilevel_flex_spec(root_node)
-
-    params = PrefixTreeParams(
-        prefix_range=(0, root_len),
-        prefix_segments=[(0, root_len)],
-        leaf_ranges=leaf_ranges,
-        leaf_segments=leaf_ranges,
-        leaf_to_sample=leaf_to_sample,
-        sample_to_leaf_range=dict(zip(leaf_to_sample, leaf_ranges, strict=False)),
-        q_ranges=q_ranges,
-        k_ranges=k_ranges,
-        mask_types=mask_types,
-        total_seqlen_q=total_tokens,
-        total_seqlen_k=total_tokens,
-        flat_tokens=flat_tokens,
-        flat_loss_mask=flat_loss_mask,
-        flat_position_ids=flat_position_ids,
-        multilevel=True,
+    return PrefixTreeMagiBatch(
+        flat_input_ids=params.flat_tokens,
+        flat_position_ids=params.flat_position_ids,
+        flat_loss_mask=params.flat_loss_mask,
+        magi_key=magi_key,
+        flex_key=flex_key,
+        leaf_to_sample=params.leaf_to_sample,
+        leaf_ranges=params.leaf_ranges,
+        prefix_range=params.prefix_range,
+        original_batch_size=num_samples,
+        real_tokens=real_tokens,
+        leaf_ancestor_ranges=getattr(params, "_leaf_ancestor_ranges", None),
+        local_flat_input_ids=params.flat_tokens,
+        local_flat_position_ids=params.flat_position_ids,
+        local_flat_loss_mask=params.flat_loss_mask,
     )
-    params._leaf_ancestor_ranges = leaf_ancestor_ranges  # attach for PrefixTreeMagiBatch
-    return params
-
-
-def build_prefix_segments_single_turn(
-    input_ids: Tensor,
-    attention_mask: Optional[Tensor] = None,
-) -> list[tuple[int, int]]:
-    """Build a single-entry prefix_segments list for one sample.
-
-    Used by RL trainers when per-sub-turn boundaries are unavailable.
-    The single entry covers the entire real (non-pad) prompt.
-
-    Args:
-        input_ids: 1-D or 2-D (1, seq_len) token tensor.
-        attention_mask: Optional 1-D or 2-D mask; when provided, only the
-            tokens where mask==1 are considered (strips padding).
-
-    Returns:
-        ``[(hash, prompt_len)]`` — a one-element prefix_segments list.
-    """
-    ids = input_ids.flatten()
-    if attention_mask is not None:
-        mask = attention_mask.flatten().bool()
-        ids = ids[mask]
-    h = _hash_prefix(ids.cpu())
-    return [(h, int(ids.numel()))]
 
 
 def _build_flex_key(params, device):
@@ -615,23 +309,15 @@ def _build_flex_key(params, device):
     """
     from torch.nn.attention.flex_attention import create_block_mask
 
-    # Build lookup arrays on CPU then move to device
     total = params.total_seqlen_q
     prefix_end = params.prefix_range[1]  # == prefix_len
 
-    # leaf_id[t] = which leaf token t belongs to (-1 = prefix)
-    import torch as _torch
-
-    leaf_id = _torch.full((total,), -1, dtype=_torch.int32)
+    leaf_id = torch.full((total,), -1, dtype=torch.int32)
     for i, (s, e) in enumerate(params.leaf_ranges):
         leaf_id[s:e] = i
     leaf_id = leaf_id.to(device)
 
     def prefix_tree_mask(b, h, q_idx, kv_idx):
-        # Within prefix: causal
-        # Leaf q attending to prefix k: always allowed
-        # Leaf q attending to same-leaf k: causal
-        # Leaf q attending to different-leaf k: blocked
         q_leaf = leaf_id[q_idx]
         k_leaf = leaf_id[kv_idx]
         in_prefix_k = kv_idx < prefix_end
@@ -664,12 +350,6 @@ def _build_magi_key(model, params):
     num_heads_kv = getattr(cfg, "num_query_groups", num_heads_q) or num_heads_q
     head_dim = cfg.kv_channels  # hidden_size // num_attention_heads
 
-    # Use the CP group so MAGI dispatch operates across CP ranks only.
-    # The key uses full T token indices (not SP-scattered) since MAGI's dispatch
-    # understands the logical token layout regardless of SP's physical distribution.
-    # NOTE: CP>1 correctness requires dispatch to operate on full T tokens before
-    # SP scatter — this is TODO. Currently dispatch/undispatch inside _magi_attn_forward
-    # operate on SP-scattered T/TP tokens which is incorrect for CP>1.
     try:
         from megatron.core import parallel_state as mpu
 
@@ -677,7 +357,7 @@ def _build_magi_key(model, params):
     except Exception:
         cp_group = dist.group.WORLD
 
-    magi_key = magi_attn_flex_key(
+    return magi_attn_flex_key(
         q_ranges=AttnRanges.from_ranges(params.q_ranges),
         k_ranges=AttnRanges.from_ranges(params.k_ranges),
         attn_mask_type=[AttnMaskType(m) for m in params.mask_types],
@@ -690,7 +370,6 @@ def _build_magi_key(model, params):
         cp_group_or_mesh=cp_group,
         dist_attn_config=DistAttnConfig(dispatch_config=DispatchConfig(uneven_shard=True)),
     )
-    return magi_key
 
 
 def _build_magi_key_sp_scaled(original_key, model, tp_size: int):
@@ -699,8 +378,6 @@ def _build_magi_key_sp_scaled(original_key, model, tp_size: int):
     With sequence_parallel=True, the embedding scatter gives T/TP tokens per TP rank.
     The MAGI key must use T/TP as total_seqlen so dispatch/undispatch in
     _magi_attn_forward operate on T/TP tokens → T/(TP*CP) per rank → back to T/TP.
-
-    This function creates a new key with all token offsets divided by tp_size.
     """
     import torch.distributed as dist
     from magi_attention.api import DistAttnConfig, magi_attn_flex_key

--- a/verl/utils/prefix_tree_magi.py
+++ b/verl/utils/prefix_tree_magi.py
@@ -30,9 +30,9 @@ Usage (inside gptmodel_forward_model_engine):
         )
         output = restore_flat_to_nested(output, pt_batch)
 """
+
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass
 from typing import Optional
 
@@ -46,8 +46,8 @@ class PrefixTreeMagiBatch:
     """Holds the flat layout and MAGI key for one prefix-tree micro-batch."""
 
     # flat input tensors ready to pass to model(...)
-    flat_input_ids: Tensor       # (total_tokens,)
-    flat_position_ids: Tensor    # (total_tokens,)
+    flat_input_ids: Tensor  # (total_tokens,)
+    flat_position_ids: Tensor  # (total_tokens,)
     flat_loss_mask: Optional[Tensor]  # (total_tokens,) or None
 
     # Attention keys — one will be None depending on prefix_tree_attention setting
@@ -124,11 +124,9 @@ def build_prefix_tree_micro_batch(
     Returns:
         PrefixTreeMagiBatch or None.
     """
-    import torch.distributed as dist
 
     from verl.utils.prefix_tree_utils import (
         build_prefix_tree_params,
-        extract_sample_tensors,
         longest_common_prefix_length,
     )
 
@@ -145,13 +143,17 @@ def build_prefix_tree_micro_batch(
 
     # Fast path: use injected prior knowledge when available.
     import os as _os
+
     if prefix_segments_batch is not None and len(prefix_segments_batch) == len(tokens_by_sample):
         prefix_len = _resolve_prefix_len_from_segments(prefix_segments_batch)
-        if _os.environ.get('DEBUG_PREFIX_LEN') == '1':
+        if _os.environ.get("DEBUG_PREFIX_LEN") == "1":
             scan_len = longest_common_prefix_length(tokens_by_sample)
             T = tokens_by_sample[0].shape[0] if tokens_by_sample else 0
-            print(f'[PREFIX_LEN] seg_len={prefix_len} scan_len={scan_len} T={T} '
-                  f'n_segs={[len(s) for s in prefix_segments_batch]}', flush=True)
+            print(
+                f"[PREFIX_LEN] seg_len={prefix_len} scan_len={scan_len} T={T} "
+                f"n_segs={[len(s) for s in prefix_segments_batch]}",
+                flush=True,
+            )
     else:
         prefix_len = longest_common_prefix_length(tokens_by_sample)
 
@@ -187,14 +189,14 @@ def build_prefix_tree_micro_batch(
     if prefix_segments_batch is not None:
         actual_root_len = longest_common_prefix_length(tokens_by_sample)
         if actual_root_len > 0:
-            multilevel_result = _resolve_multilevel_tree(
-                tokens_by_sample, prefix_segments_batch, actual_root_len
-            )
+            multilevel_result = _resolve_multilevel_tree(tokens_by_sample, prefix_segments_batch, actual_root_len)
 
     if multilevel_result is not None:
         root_len, children_info = multilevel_result
         params = _build_multilevel_prefix_tree_params(
-            tokens_by_sample, root_len, children_info,
+            tokens_by_sample,
+            root_len,
+            children_info,
             loss_masks_by_sample=loss_masks_by_sample,
             position_ids_by_sample=position_ids_by_sample,
         )
@@ -216,13 +218,13 @@ def build_prefix_tree_micro_batch(
         pad_len = (align_size - total % align_size) % align_size
         if pad_len > 0:
             import torch as _torch
-            params.flat_tokens = _torch.cat(
-                [params.flat_tokens, params.flat_tokens.new_zeros(pad_len)])
+
+            params.flat_tokens = _torch.cat([params.flat_tokens, params.flat_tokens.new_zeros(pad_len)])
             params.flat_position_ids = _torch.cat(
-                [params.flat_position_ids, params.flat_position_ids.new_zeros(pad_len)])
+                [params.flat_position_ids, params.flat_position_ids.new_zeros(pad_len)]
+            )
             if params.flat_loss_mask is not None:
-                params.flat_loss_mask = _torch.cat(
-                    [params.flat_loss_mask, params.flat_loss_mask.new_zeros(pad_len)])
+                params.flat_loss_mask = _torch.cat([params.flat_loss_mask, params.flat_loss_mask.new_zeros(pad_len)])
             params.total_seqlen_q += pad_len
             params.total_seqlen_k += pad_len
             # Do NOT add rectangles for padding tokens — they are stripped before loss.
@@ -256,7 +258,7 @@ def build_prefix_tree_micro_batch(
         prefix_range=params.prefix_range,
         original_batch_size=params.num_samples,
         real_tokens=real_tokens,
-        leaf_ancestor_ranges=getattr(params, '_leaf_ancestor_ranges', None),
+        leaf_ancestor_ranges=getattr(params, "_leaf_ancestor_ranges", None),
         local_flat_input_ids=local_flat_tokens,
         local_flat_position_ids=local_flat_position_ids,
         local_flat_loss_mask=local_flat_loss_mask,
@@ -320,9 +322,11 @@ def _hash_prefix(token_ids_flat: Tensor) -> int:
     raw = token_ids_flat.numpy().tobytes()
     try:
         import xxhash  # type: ignore[import]
+
         return xxhash.xxh128_intdigest(raw)
     except ImportError:
         import hashlib
+
         return int.from_bytes(hashlib.md5(raw).digest(), "little")
 
 
@@ -374,6 +378,7 @@ def _resolve_multilevel_tree(
     have ≥2 samples, a 2-level tree exists and we return a TreeNode root.
     """
     from collections import defaultdict
+
     from verl.utils.prefix_tree_utils import TreeNode
 
     n = len(tokens_by_sample)
@@ -400,6 +405,7 @@ def _resolve_multilevel_tree(
     # Use token scan (not segment hashes) to get exact turn2 shared prefix length per group.
     # Segment hashes can mis-align due to chat-template boundary effects.
     from verl.utils.prefix_tree_utils import longest_common_prefix_length
+
     children = []
     for _h, idxs in useful:
         group_tokens = [tokens_by_sample[i] for i in idxs]
@@ -409,8 +415,7 @@ def _resolve_multilevel_tree(
         if shared_suffix_len <= 0:
             return None
         group_turn2_len = shared_suffix_len
-        leaves = [TreeNode(int(tokens_by_sample[i].shape[0]) - root_prefix_len - group_turn2_len, [])
-                  for i in idxs]
+        leaves = [TreeNode(int(tokens_by_sample[i].shape[0]) - root_prefix_len - group_turn2_len, []) for i in idxs]
         if any(leaf.segment_len <= 0 for leaf in leaves):
             return None
         children.append((idxs, TreeNode(group_turn2_len, leaves)))
@@ -427,8 +432,9 @@ def _build_multilevel_prefix_tree_params(
 ):
     """Build PrefixTreeParams for a 2-level tree using build_multilevel_flex_spec."""
     import torch
-    from verl.utils.prefix_tree_utils import TreeNode, build_multilevel_flex_spec
+
     from verl.utils.prefix_tree_params import PrefixTreeParams
+    from verl.utils.prefix_tree_utils import TreeNode, build_multilevel_flex_spec
 
     # Build TreeNode for flex_spec
     tree_children = [child_node for _, child_node in children_info]
@@ -442,6 +448,7 @@ def _build_multilevel_prefix_tree_params(
         for child in node.children:
             cur = _assign_offsets(child, cur)
         return cur
+
     total_tokens = _assign_offsets(root_node, 0)
 
     # Build flat token tensor: root + each child group + each leaf in DFS order
@@ -470,21 +477,20 @@ def _build_multilevel_prefix_tree_params(
         # internal node: add this node's own tokens (shared by its group)
         sample_idx = sample_idxs_list[0]
         tok = tokens_by_sample[sample_idx]
-        node_start_in_sample = node._flat_start  # offset in flat layout
         # Compute where this node's tokens start in the original sample
         # For root: sample[0:root_len]
         # For depth-1 child: sample[root_len : root_len + child.segment_len]
         if depth == 0:
-            content = tok[:node._flat_end]  # root tokens
+            content = tok[: node._flat_end]  # root tokens
         else:
-            content = tok[root_len: root_len + node.segment_len]  # turn2 tokens
+            content = tok[root_len : root_len + node.segment_len]  # turn2 tokens
         flat_parts.append(content)
 
         # Recurse into children, distributing sample indices
         leaf_idx = 0
         for child in node.children:
             n_leaves = _count_leaves(child)
-            _flatten_node(child, sample_idxs_list[leaf_idx:leaf_idx + n_leaves], depth + 1)
+            _flatten_node(child, sample_idxs_list[leaf_idx : leaf_idx + n_leaves], depth + 1)
             leaf_idx += n_leaves
 
     def _count_leaves(node):
@@ -502,19 +508,18 @@ def _build_multilevel_prefix_tree_params(
     for child_idxs, child_node in children_info:
         # Add turn2 tokens (from first sample of this group)
         sample0 = child_idxs[0]
-        turn2_tokens = tokens_by_sample[sample0][root_len: root_len + child_node.segment_len]
+        turn2_tokens = tokens_by_sample[sample0][root_len : root_len + child_node.segment_len]
         flat_parts.append(turn2_tokens)
         turn2_flat_start = cur_offset
         cur_offset += child_node.segment_len
         turn2_flat_range = (turn2_flat_start, cur_offset)
 
         # Add each leaf
-        for leaf_node, sample_idx in zip(child_node.children, child_idxs):
+        for leaf_node, sample_idx in zip(child_node.children, child_idxs, strict=False):
             leaf_start = cur_offset
             leaf_len = leaf_node.segment_len
-            leaf_tokens = tokens_by_sample[sample_idx][root_len + child_node.segment_len:]
-            assert leaf_tokens.shape[0] == leaf_len, \
-                f"leaf token mismatch: {leaf_tokens.shape[0]} != {leaf_len}"
+            leaf_tokens = tokens_by_sample[sample_idx][root_len + child_node.segment_len :]
+            assert leaf_tokens.shape[0] == leaf_len, f"leaf token mismatch: {leaf_tokens.shape[0]} != {leaf_len}"
             flat_parts.append(leaf_tokens)
             leaf_ranges.append((leaf_start, leaf_start + leaf_len))
             leaf_to_sample.append(sample_idx)
@@ -522,8 +527,7 @@ def _build_multilevel_prefix_tree_params(
             cur_offset += leaf_len
 
     flat_tokens = torch.cat(flat_parts)
-    assert flat_tokens.shape[0] == total_tokens, \
-        f"flat token count mismatch: {flat_tokens.shape[0]} != {total_tokens}"
+    assert flat_tokens.shape[0] == total_tokens, f"flat token count mismatch: {flat_tokens.shape[0]} != {total_tokens}"
 
     # Build loss mask
     flat_loss_mask = None
@@ -531,9 +535,9 @@ def _build_multilevel_prefix_tree_params(
         lm_parts = [loss_masks_by_sample[0][:root_len]]
         for child_idxs, child_node in children_info:
             sample0 = child_idxs[0]
-            lm_parts.append(loss_masks_by_sample[sample0][root_len: root_len + child_node.segment_len])
-            for leaf_node, sample_idx in zip(child_node.children, child_idxs):
-                lm_parts.append(loss_masks_by_sample[sample_idx][root_len + child_node.segment_len:])
+            lm_parts.append(loss_masks_by_sample[sample0][root_len : root_len + child_node.segment_len])
+            for leaf_node, sample_idx in zip(child_node.children, child_idxs, strict=False):
+                lm_parts.append(loss_masks_by_sample[sample_idx][root_len + child_node.segment_len :])
         flat_loss_mask = torch.cat(lm_parts)
 
     # Build position ids: root is 0..root_len-1, each turn2 starts at root_len,
@@ -544,7 +548,7 @@ def _build_multilevel_prefix_tree_params(
     for child_idxs, child_node in children_info:
         # turn2 positions: root_len .. root_len + turn2_len - 1
         pid_parts.append(torch.arange(root_len, root_len + child_node.segment_len, device=device))
-        for leaf_node, _sample_idx in zip(child_node.children, child_idxs):
+        for leaf_node, _sample_idx in zip(child_node.children, child_idxs, strict=False):
             # leaf positions: root_len + turn2_len .. root_len + turn2_len + leaf_len - 1
             leaf_start_pos = root_len + child_node.segment_len
             pid_parts.append(torch.arange(leaf_start_pos, leaf_start_pos + leaf_node.segment_len, device=device))
@@ -559,7 +563,7 @@ def _build_multilevel_prefix_tree_params(
         leaf_ranges=leaf_ranges,
         leaf_segments=leaf_ranges,
         leaf_to_sample=leaf_to_sample,
-        sample_to_leaf_range=dict(zip(leaf_to_sample, leaf_ranges)),
+        sample_to_leaf_range=dict(zip(leaf_to_sample, leaf_ranges, strict=False)),
         q_ranges=q_ranges,
         k_ranges=k_ranges,
         mask_types=mask_types,
@@ -617,6 +621,7 @@ def _build_flex_key(params, device):
 
     # leaf_id[t] = which leaf token t belongs to (-1 = prefix)
     import torch as _torch
+
     leaf_id = _torch.full((total,), -1, dtype=_torch.int32)
     for i, (s, e) in enumerate(params.leaf_ranges):
         leaf_id[s:e] = i
@@ -636,9 +641,9 @@ def _build_flex_key(params, device):
 
     # _compile=False: avoid Triton JIT which takes minutes for new shapes.
     # Memory is handled at the call site via torch.utils.checkpoint.
-    block_mask = create_block_mask(prefix_tree_mask, B=None, H=None,
-                                   Q_LEN=total, KV_LEN=total, device=device,
-                                   _compile=False)
+    block_mask = create_block_mask(
+        prefix_tree_mask, B=None, H=None, Q_LEN=total, KV_LEN=total, device=device, _compile=False
+    )
     block_mask._leaf_id = leaf_id  # keep closure alive
     return block_mask
 
@@ -656,7 +661,7 @@ def _build_magi_key(model, params):
     cfg = unwrap_model(model).config
     num_heads_q = cfg.num_attention_heads
     # GQA: num_query_groups may be set; fall back to num_heads_q if not
-    num_heads_kv = getattr(cfg, 'num_query_groups', num_heads_q) or num_heads_q
+    num_heads_kv = getattr(cfg, "num_query_groups", num_heads_q) or num_heads_q
     head_dim = cfg.kv_channels  # hidden_size // num_attention_heads
 
     # Use the CP group so MAGI dispatch operates across CP ranks only.
@@ -667,6 +672,7 @@ def _build_magi_key(model, params):
     # operate on SP-scattered T/TP tokens which is incorrect for CP>1.
     try:
         from megatron.core import parallel_state as mpu
+
         cp_group = mpu.get_context_parallel_group()
     except Exception:
         cp_group = dist.group.WORLD
@@ -682,9 +688,7 @@ def _build_magi_key(model, params):
         head_dim=head_dim,
         pad_size=0,
         cp_group_or_mesh=cp_group,
-        dist_attn_config=DistAttnConfig(
-            dispatch_config=DispatchConfig(uneven_shard=True)
-        ),
+        dist_attn_config=DistAttnConfig(dispatch_config=DispatchConfig(uneven_shard=True)),
     )
     return magi_key
 
@@ -701,19 +705,17 @@ def _build_magi_key_sp_scaled(original_key, model, tp_size: int):
     import torch.distributed as dist
     from magi_attention.api import DistAttnConfig, magi_attn_flex_key
     from magi_attention.common import AttnRanges
-    from magi_attention.common.enum import AttnMaskType
     from magi_attention.meta.solver.dispatch_solver import DispatchConfig
 
     try:
         from megatron.core import parallel_state as mpu
+
         cp_group = mpu.get_context_parallel_group()
     except Exception:
         cp_group = dist.group.WORLD
 
-    q_ranges_sp = [(r.start // tp_size, r.end // tp_size)
-                   for r in original_key.q_ranges]
-    k_ranges_sp = [(r.start // tp_size, r.end // tp_size)
-                   for r in original_key.k_ranges]
+    q_ranges_sp = [(r.start // tp_size, r.end // tp_size) for r in original_key.q_ranges]
+    k_ranges_sp = [(r.start // tp_size, r.end // tp_size) for r in original_key.k_ranges]
     total_q_sp = original_key.total_seqlen_q // tp_size
     total_k_sp = original_key.total_seqlen_k // tp_size
 
@@ -728,7 +730,5 @@ def _build_magi_key_sp_scaled(original_key, model, tp_size: int):
         head_dim=original_key.head_dim,
         pad_size=0,
         cp_group_or_mesh=cp_group,
-        dist_attn_config=DistAttnConfig(
-            dispatch_config=DispatchConfig(uneven_shard=True)
-        ),
+        dist_attn_config=DistAttnConfig(dispatch_config=DispatchConfig(uneven_shard=True)),
     )

--- a/verl/utils/prefix_tree_params.py
+++ b/verl/utils/prefix_tree_params.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import annotations
 
@@ -52,7 +64,7 @@ class PrefixTreeParams:
         if prefix_end < prefix_start:
             raise ValueError("prefix_range must be non-decreasing")
 
-        for leaf_range, leaf_segment in zip(self.leaf_ranges, self.leaf_segments):
+        for leaf_range, leaf_segment in zip(self.leaf_ranges, self.leaf_segments, strict=False):
             leaf_start, leaf_end = leaf_range
             if leaf_end < leaf_start:
                 raise ValueError("leaf ranges must be non-decreasing")
@@ -75,11 +87,11 @@ class PrefixTreeParams:
                     raise ValueError("leaf ranges must start at or after the shared prefix")
             expected_ranges = [self.prefix_range]
             expected_k_ranges = [self.prefix_range]
-            expected_mask_types = ['causal']
+            expected_mask_types = ["causal"]
             for leaf_range in self.leaf_ranges:
                 expected_ranges.extend([leaf_range, leaf_range])
                 expected_k_ranges.extend([self.prefix_range, leaf_range])
-                expected_mask_types.extend(['full', 'causal'])
+                expected_mask_types.extend(["full", "causal"])
             if self.q_ranges != expected_ranges:
                 raise ValueError("q_ranges do not match root-shared PrefixTree layout")
             if self.k_ranges != expected_k_ranges:
@@ -87,15 +99,15 @@ class PrefixTreeParams:
             if self.mask_types != expected_mask_types:
                 raise ValueError("mask_types do not match root-shared PrefixTree layout")
 
-        for sample_idx, leaf_range in zip(self.leaf_to_sample, self.leaf_ranges):
+        for sample_idx, leaf_range in zip(self.leaf_to_sample, self.leaf_ranges, strict=False):
             if self.sample_to_leaf_range[sample_idx] != leaf_range:
                 raise ValueError("sample_to_leaf_range does not match leaf_to_sample ordering")
 
         for name, tensor in {
-            'flat_tokens': self.flat_tokens,
-            'flat_labels': self.flat_labels,
-            'flat_loss_mask': self.flat_loss_mask,
-            'flat_position_ids': self.flat_position_ids,
+            "flat_tokens": self.flat_tokens,
+            "flat_labels": self.flat_labels,
+            "flat_loss_mask": self.flat_loss_mask,
+            "flat_position_ids": self.flat_position_ids,
         }.items():
             if tensor is not None and tensor.numel() != self.total_seqlen_q:
                 raise ValueError(f"{name} must have total_seqlen_q elements")

--- a/verl/utils/prefix_tree_utils.py
+++ b/verl/utils/prefix_tree_utils.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import annotations
 
@@ -12,14 +24,14 @@ from torch import Tensor
 from verl.utils.prefix_tree_params import PrefixTreeParams, RangeSpec
 
 __all__ = [
-    'TreeNode',
-    'build_prefix_tree_dense_mask',
-    'build_prefix_tree_flex_spec',
-    'build_multilevel_flex_spec',
-    'build_prefix_tree_params',
-    'extract_sample_tensor',
-    'extract_sample_tensors',
-    'longest_common_prefix_length',
+    "TreeNode",
+    "build_prefix_tree_dense_mask",
+    "build_prefix_tree_flex_spec",
+    "build_multilevel_flex_spec",
+    "build_prefix_tree_params",
+    "extract_sample_tensor",
+    "extract_sample_tensors",
+    "longest_common_prefix_length",
 ]
 
 
@@ -44,7 +56,7 @@ class TreeNode:
     """
 
     segment_len: int
-    children: list['TreeNode'] = field(default_factory=list)
+    children: list[TreeNode] = field(default_factory=list)
 
     @property
     def is_leaf(self) -> bool:
@@ -61,7 +73,7 @@ def build_prefix_tree_flex_spec(
 
     q_ranges: list[RangeSpec] = [(0, prefix_len)]
     k_ranges: list[RangeSpec] = [(0, prefix_len)]
-    mask_types = ['causal']
+    mask_types = ["causal"]
 
     current = prefix_len
     for branch_len in branch_lengths:
@@ -71,18 +83,18 @@ def build_prefix_tree_flex_spec(
         branch_range = (current, current + branch_len)
         q_ranges.append(branch_range)
         k_ranges.append((0, prefix_len))
-        mask_types.append('full')
+        mask_types.append("full")
 
         q_ranges.append(branch_range)
         k_ranges.append(branch_range)
-        mask_types.append('causal')
+        mask_types.append("causal")
         current += branch_len
 
     return q_ranges, k_ranges, mask_types
 
 
 def build_multilevel_flex_spec(
-    root: 'TreeNode',
+    root: TreeNode,
 ) -> tuple[list[RangeSpec], list[RangeSpec], list[str]]:
     """Encode a multi-level prefix tree as MAGI flex rectangles.
 
@@ -139,7 +151,7 @@ def build_multilevel_flex_spec(
         # Self-attention: causal over this node's own tokens.
         q_ranges.append(node_range)
         k_ranges.append(node_range)
-        mask_types.append('causal')
+        mask_types.append("causal")
 
         if node.is_leaf:
             return
@@ -151,7 +163,7 @@ def build_multilevel_flex_spec(
             desc_range: RangeSpec = (desc._flat_start, desc._flat_end)  # type: ignore[attr-defined]
             q_ranges.append(desc_range)
             k_ranges.append(node_range)
-            mask_types.append('full')
+            mask_types.append("full")
 
         for child in node.children:
             _emit_node(child)
@@ -176,7 +188,7 @@ def build_prefix_tree_dense_mask(
         raise ValueError("total_tokens must be non-negative")
 
     mask = torch.zeros(total_tokens, total_tokens, dtype=torch.bool, device=device)
-    for (q_start, q_end), (k_start, k_end), mask_type in zip(q_ranges, k_ranges, mask_types):
+    for (q_start, q_end), (k_start, k_end), mask_type in zip(q_ranges, k_ranges, mask_types, strict=False):
         if q_start < 0 or k_start < 0 or q_end < q_start or k_end < k_start:
             raise ValueError("range specs must be non-decreasing and non-negative")
         if q_end > total_tokens or k_end > total_tokens:
@@ -184,10 +196,10 @@ def build_prefix_tree_dense_mask(
         if q_end == q_start or k_end == k_start:
             continue
 
-        if mask_type == 'full':
+        if mask_type == "full":
             mask[q_start:q_end, k_start:k_end] = True
             continue
-        if mask_type != 'causal':
+        if mask_type != "causal":
             raise ValueError(f"Unsupported mask type: {mask_type}")
 
         q_pos = torch.arange(q_start, q_end, device=mask.device).unsqueeze(1)
@@ -199,7 +211,7 @@ def build_prefix_tree_dense_mask(
 
 def longest_common_prefix_length(sequences: Sequence[Tensor]) -> int:
     """Return the longest common token prefix across 1D tensors."""
-    reference = _validate_sequence_field('sequences', sequences)
+    reference = _validate_sequence_field("sequences", sequences)
     prefix_len = reference.numel()
 
     for sequence in sequences[1:]:
@@ -231,7 +243,7 @@ def build_prefix_tree_params(
     samples. Autoregressive next-token labels often diverge at the prefix/leaf boundary, so callers
     should omit labels unless they have already accounted for that ambiguity.
     """
-    tokens_reference = _validate_sequence_field('tokens_by_sample', tokens_by_sample)
+    tokens_reference = _validate_sequence_field("tokens_by_sample", tokens_by_sample)
     normalized_sample_indices = _normalize_sample_indices(len(tokens_by_sample), sample_indices)
 
     if prefix_len is None:
@@ -241,23 +253,21 @@ def build_prefix_tree_params(
             raise ValueError("prefix_len must be non-negative")
         if prefix_len > min(sequence.numel() for sequence in tokens_by_sample):
             raise ValueError("prefix_len cannot exceed the shortest sequence")
-        _validate_shared_prefix('tokens_by_sample', tokens_by_sample, prefix_len)
+        _validate_shared_prefix("tokens_by_sample", tokens_by_sample, prefix_len)
 
     branch_lengths = [sequence.numel() - prefix_len for sequence in tokens_by_sample]
     prefix_range = (0, prefix_len)
     leaf_ranges = _build_leaf_ranges(prefix_len, branch_lengths)
     q_ranges, k_ranges, mask_types = build_prefix_tree_flex_spec(prefix_len, branch_lengths)
 
-    flat_tokens = _flatten_root_shared_field('tokens_by_sample', tokens_by_sample, prefix_len)
-    flat_labels = _flatten_optional_field('labels_by_sample', labels_by_sample, tokens_by_sample, prefix_len)
-    flat_loss_mask = _flatten_optional_field(
-        'loss_masks_by_sample', loss_masks_by_sample, tokens_by_sample, prefix_len
-    )
+    flat_tokens = _flatten_root_shared_field("tokens_by_sample", tokens_by_sample, prefix_len)
+    flat_labels = _flatten_optional_field("labels_by_sample", labels_by_sample, tokens_by_sample, prefix_len)
+    flat_loss_mask = _flatten_optional_field("loss_masks_by_sample", loss_masks_by_sample, tokens_by_sample, prefix_len)
     if position_ids_by_sample is None:
         flat_position_ids = _build_default_position_ids(prefix_len, branch_lengths, tokens_reference.device)
     else:
         flat_position_ids = _flatten_optional_field(
-            'position_ids_by_sample', position_ids_by_sample, tokens_by_sample, prefix_len
+            "position_ids_by_sample", position_ids_by_sample, tokens_by_sample, prefix_len
         )
 
     return PrefixTreeParams(
@@ -266,7 +276,7 @@ def build_prefix_tree_params(
         leaf_ranges=leaf_ranges,
         leaf_segments=list(leaf_ranges),
         leaf_to_sample=list(normalized_sample_indices),
-        sample_to_leaf_range=dict(zip(normalized_sample_indices, leaf_ranges)),
+        sample_to_leaf_range=dict(zip(normalized_sample_indices, leaf_ranges, strict=False)),
         q_ranges=q_ranges,
         k_ranges=k_ranges,
         mask_types=mask_types,
@@ -372,11 +382,9 @@ def _validate_auxiliary_field(
     _validate_sequence_field(name, field_by_sample)
     if len(field_by_sample) != len(tokens_by_sample):
         raise ValueError(f"{name} must have the same length as tokens_by_sample")
-    for index, (field_tensor, token_tensor) in enumerate(zip(field_by_sample, tokens_by_sample)):
+    for index, (field_tensor, token_tensor) in enumerate(zip(field_by_sample, tokens_by_sample, strict=False)):
         if field_tensor.numel() != token_tensor.numel():
-            raise ValueError(
-                f"{name}[{index}] must have the same number of elements as tokens_by_sample[{index}]"
-            )
+            raise ValueError(f"{name}[{index}] must have the same number of elements as tokens_by_sample[{index}]")
 
 
 def _validate_sequence_field(name: str, sequences: Sequence[Tensor]) -> Tensor:

--- a/verl/utils/prefix_tree_utils.py
+++ b/verl/utils/prefix_tree_utils.py
@@ -28,6 +28,7 @@ __all__ = [
     "build_prefix_tree_dense_mask",
     "build_prefix_tree_flex_spec",
     "build_multilevel_flex_spec",
+    "build_layout_from_tree_node",
     "build_prefix_tree_params",
     "extract_sample_tensor",
     "extract_sample_tensors",
@@ -171,6 +172,145 @@ def build_multilevel_flex_spec(
     _emit_node(root)
 
     return q_ranges, k_ranges, mask_types
+
+
+def build_layout_from_tree_node(
+    samples: Sequence[Tensor],
+    tree_root: TreeNode,
+    leaf_to_sample: Sequence[int],
+    loss_masks_by_sample: Optional[Sequence[Tensor]] = None,
+    position_ids_by_sample: Optional[Sequence[Tensor]] = None,
+) -> PrefixTreeParams:
+    """Build flat layout (PrefixTreeParams) from a TreeNode spec.
+
+    Consumed by the dynamic-trie detection path: ``build_tree_dynamic`` produces
+    a ``(TreeNode, leaf_to_sample)`` pair describing the LOGICAL shared-prefix
+    structure, and this function realises it as a PHYSICAL flat token layout
+    plus q/k attention rectangles.
+
+    For each node we track an "owner" sample (the first leaf descendant) and an
+    "owner offset" (the cumulative segment_len of all ancestors). The owner's
+    token slice at ``[offset, offset+segment_len)`` is what gets emitted into
+    the flat tensor for that node.
+
+    Args:
+        samples: Per-sample 1-D token tensors. ``samples[i]`` is the original
+            sequence for sample ``i``.
+        tree_root: Root of the prefix tree. Its ``segment_len`` is the length
+            of the shared root prefix.
+        leaf_to_sample: For each leaf in DFS pre-order, the original sample
+            index this leaf corresponds to. Length must equal the number of
+            leaves in ``tree_root``.
+        loss_masks_by_sample / position_ids_by_sample: optional per-sample
+            auxiliary tensors. When None, position ids default to
+            ``arange(owner_offset, owner_offset + segment_len)`` so each
+            sample's RoPE positions match the original layout.
+
+    Returns:
+        PrefixTreeParams with ``multilevel=True``. Also stashes
+        ``_leaf_ancestor_ranges`` on the params instance for downstream
+        ``restore_flat_to_nested``.
+    """
+    # build_multilevel_flex_spec assigns _flat_start / _flat_end to every node
+    # as a side effect — we rely on that for leaf_ranges + ancestor ranges below.
+    q_ranges, k_ranges, mask_types = build_multilevel_flex_spec(tree_root)
+
+    # Walk top-down: assign each node its owner sample (first leaf descendant)
+    # and owner offset (= sum of ancestor segment_lens). Also collect leaves in
+    # DFS order and a parent_of map for restoring ancestor chains.
+    leaves_in_dfs: list[TreeNode] = []
+    parent_of: dict[int, TreeNode] = {}
+    leaf_cursor = [0]  # mutable closure cell
+
+    def _annotate(node: TreeNode, owner_offset: int) -> int:
+        node._owner_offset = owner_offset  # type: ignore[attr-defined]
+        if node.is_leaf:
+            sample_idx = int(leaf_to_sample[leaf_cursor[0]])
+            leaf_cursor[0] += 1
+            node._owner_sample = sample_idx  # type: ignore[attr-defined]
+            leaves_in_dfs.append(node)
+            return sample_idx
+        child_offset = owner_offset + node.segment_len
+        first_owner: Optional[int] = None
+        for i, child in enumerate(node.children):
+            parent_of[id(child)] = node
+            owner = _annotate(child, child_offset)
+            if i == 0:
+                first_owner = owner
+        node._owner_sample = first_owner  # type: ignore[attr-defined]
+        return first_owner  # type: ignore[return-value]
+
+    _annotate(tree_root, 0)
+
+    # Emit flat tokens via DFS pre-order using each node's (owner_sample, owner_offset).
+    device = samples[0].device
+    flat_pieces: list[Tensor] = []
+    flat_lm_pieces: Optional[list[Tensor]] = [] if loss_masks_by_sample is not None else None
+    flat_pid_pieces: Optional[list[Tensor]] = [] if position_ids_by_sample is not None else None
+    default_pid_pieces: list[Tensor] = []
+
+    def _emit(node: TreeNode) -> None:
+        if node.segment_len > 0:
+            owner = node._owner_sample  # type: ignore[attr-defined]
+            s = node._owner_offset  # type: ignore[attr-defined]
+            e = s + node.segment_len
+            flat_pieces.append(samples[owner][s:e])
+            if flat_lm_pieces is not None:
+                flat_lm_pieces.append(loss_masks_by_sample[owner][s:e])
+            if flat_pid_pieces is not None:
+                flat_pid_pieces.append(position_ids_by_sample[owner][s:e])
+            else:
+                default_pid_pieces.append(torch.arange(s, e, device=device, dtype=torch.long))
+        for child in node.children:
+            _emit(child)
+
+    _emit(tree_root)
+
+    flat_tokens = torch.cat(flat_pieces) if flat_pieces else torch.empty(0, dtype=samples[0].dtype, device=device)
+    flat_loss_mask = torch.cat(flat_lm_pieces) if flat_lm_pieces is not None else None
+    if flat_pid_pieces is not None:
+        flat_position_ids = torch.cat(flat_pid_pieces)
+    else:
+        flat_position_ids = (
+            torch.cat(default_pid_pieces) if default_pid_pieces else torch.empty(0, dtype=torch.long, device=device)
+        )
+
+    leaf_ranges = [(leaf._flat_start, leaf._flat_end) for leaf in leaves_in_dfs]  # type: ignore[attr-defined]
+    leaf_to_sample_list = [int(s) for s in leaf_to_sample]
+    sample_to_leaf_range = {s: r for s, r in zip(leaf_to_sample_list, leaf_ranges, strict=False)}
+
+    leaf_ancestor_ranges: list[list[RangeSpec]] = []
+    for leaf in leaves_in_dfs:
+        chain: list[RangeSpec] = []
+        cur = parent_of.get(id(leaf))
+        while cur is not None:
+            chain.append((cur._flat_start, cur._flat_end))  # type: ignore[attr-defined]
+            cur = parent_of.get(id(cur))
+        chain.reverse()  # root first
+        leaf_ancestor_ranges.append(chain)
+
+    prefix_range = (tree_root._flat_start, tree_root._flat_end)  # type: ignore[attr-defined]
+
+    params = PrefixTreeParams(
+        prefix_range=prefix_range,
+        prefix_segments=[prefix_range],
+        leaf_ranges=leaf_ranges,
+        leaf_segments=list(leaf_ranges),
+        leaf_to_sample=leaf_to_sample_list,
+        sample_to_leaf_range=sample_to_leaf_range,
+        q_ranges=q_ranges,
+        k_ranges=k_ranges,
+        mask_types=mask_types,
+        total_seqlen_q=flat_tokens.numel(),
+        total_seqlen_k=flat_tokens.numel(),
+        flat_tokens=flat_tokens,
+        flat_labels=None,
+        flat_loss_mask=flat_loss_mask,
+        flat_position_ids=flat_position_ids,
+        multilevel=True,
+    )
+    params._leaf_ancestor_ranges = leaf_ancestor_ranges  # type: ignore[attr-defined]
+    return params
 
 
 def build_prefix_tree_dense_mask(

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -218,6 +218,31 @@ class FSDPEngine(BaseEngine):
 
         self.use_ulysses_sp = self.ulysses_sequence_parallel_size > 1
 
+        # Magi CP device mesh + group (orthogonal to FSDP DP). Always built —
+        # even at cp_size=1 — so we can pass a concrete cp_group instead of
+        # dist.group.WORLD, which Magi would treat as CP=world and break a2av.
+        self.context_parallel_size = getattr(self.engine_config, "context_parallel_size", 1)
+        self.cp_device_mesh = None
+        self.cp_group = None
+        if self.context_parallel_size > 1:
+            assert not self.use_ulysses_sp, (
+                "context_parallel_size > 1 (Magi CP) is mutually exclusive with "
+                "ulysses_sequence_parallel_size > 1; pick one parallelism scheme."
+            )
+        # Compute the CP-side dp locally (get_data_parallel_size doesn't account
+        # for CP). cp_size=1 → (world, 1) mesh, each rank gets a size-1 cp_group.
+        cp_dp_size = world_size // self.context_parallel_size
+        assert cp_dp_size * self.context_parallel_size == world_size, (
+            f"world_size ({world_size}) not divisible by context_parallel_size "
+            f"({self.context_parallel_size}); choose a cp_size that divides world_size"
+        )
+        self.cp_device_mesh = init_device_mesh(
+            device_name,
+            mesh_shape=(cp_dp_size, self.context_parallel_size),
+            mesh_dim_names=["dp", "cp"],
+        )
+        self.cp_group = self.cp_device_mesh["cp"].get_group()
+
     def _build_module(self):
         from verl.utils.model import get_hf_auto_model_class
         from verl.utils.torch_dtypes import PrecisionType
@@ -286,7 +311,29 @@ class FSDPEngine(BaseEngine):
                 ulysses_sp_size=self.ulysses_sequence_parallel_size,
                 use_fused_kernels=use_fused_kernels,
                 fused_kernels_backend=fused_kernels_backend,
+                use_prefix_tree_dynamic=getattr(self.engine_config, "use_prefix_tree_dynamic", False),
             )
+
+            # dynamic prefix-tree + Magi: attach cp_group to every attention
+            # module and flip _attn_implementation so HF dispatches through Magi.
+            if getattr(self.engine_config, "use_prefix_tree_dynamic", False):
+                # FSDP1 + Magi has EVAL/TRAIN forward divergence (ppo_kl ≈ 3,
+                # intermittent NaN grad). MagiAttention's reference example uses FSDP2.
+                assert self.engine_config.strategy == "fsdp2", (
+                    f"use_prefix_tree_dynamic=True requires engine.strategy='fsdp2'; "
+                    f"got '{self.engine_config.strategy}'."
+                )
+                attn_backend = getattr(self.engine_config, "prefix_tree_attention", "magi")
+                assert attn_backend == "magi", f"prefix_tree_attention='{attn_backend}' unsupported on FSDP."
+                self._attach_magi_cp_group_to_attention_modules(module)
+                # HF reads _attn_implementation per-config; cover composite (VL) configs too.
+                cfgs_to_flip = [module.config]
+                for sub in ("text_config", "vision_config"):
+                    sub_cfg = getattr(module.config, sub, None)
+                    if sub_cfg is not None:
+                        cfgs_to_flip.append(sub_cfg)
+                for cfg in cfgs_to_flip:
+                    cfg._attn_implementation = "Magi_Attention"
 
             # some parameters may not in torch_dtype
             module.to(torch_dtype)
@@ -294,6 +341,29 @@ class FSDPEngine(BaseEngine):
             if self.model_config.enable_gradient_checkpointing:
                 module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
         return module
+
+    def _attach_magi_cp_group_to_attention_modules(self, model):
+        """Walk model and attach ``cp_group`` attribute to each attention layer.
+
+        Magi's HF backend reads the group via ``module.cp_group``. We use the
+        CP process group from ``_init_device_mesh``; falls back to the world
+        group when CP is not configured (cp_size=1 single-rank case).
+        """
+        cp_group = self.cp_group
+        if cp_group is None and torch.distributed.is_initialized():
+            cp_group = torch.distributed.group.WORLD
+        attached = 0
+        for name, mod in model.named_modules():
+            cls_name = mod.__class__.__name__.lower()
+            if cls_name.endswith("attention") or cls_name.endswith("self_attn") or cls_name.endswith("selfattention"):
+                mod.cp_group = cp_group
+                attached += 1
+        if (
+            torch.distributed.is_initialized()
+            and torch.distributed.get_rank() == 0
+            or not torch.distributed.is_initialized()
+        ):
+            print(f"[PrefixTreeDynamic] Attached cp_group to {attached} attention modules")
 
     def _build_lora_module(self, module):
         module.enable_input_require_grads()
@@ -602,7 +672,9 @@ class FSDPEngine(BaseEngine):
         raise NotImplementedError
 
     def get_context_parallel_group(self):
-        raise NotImplementedError
+        # Magi CP group when context_parallel_size > 1, else fall back to a
+        # single-rank group (None / world).
+        return self.cp_group
 
     def forward_backward_batch(self, data: TensorDict, loss_function: Callable, forward_only=False) -> list[TensorDict]:
         # note that the global_batch_size should include data on all the dp
@@ -1208,6 +1280,36 @@ class FSDPEngineWithLMHead(FSDPEngine):
         micro_batch = micro_batch.to(get_device_id())
         model_inputs, output_args = self.prepare_model_inputs(micro_batch=micro_batch)
 
+        # ── Optional memory profiling (set PROFILE_MEMORY_LOG=1 to enable).
+        # Logs allocated + max_allocated at three checkpoints per forward_step
+        # so we can A/B tree vs dense and find the phase where the diff lives.
+        _profile_mem = os.environ.get("PROFILE_MEMORY_LOG", "0") == "1"
+        _profile_mem_rank = int(os.environ.get("PROFILE_MEMORY_LOG_RANK", "0"))
+        _profile_mem_active = _profile_mem and torch.distributed.get_rank() == _profile_mem_rank
+
+        def _mem_log(phase: str):
+            if not _profile_mem_active:
+                return
+            alloc = torch.cuda.memory_allocated() / 1e9
+            peak = torch.cuda.max_memory_allocated() / 1e9
+            print(
+                f"[MEM] forward_step phase={phase} forward_only={forward_only} "
+                f"tree={tu.get_non_tensor_data(data=micro_batch, key='use_prefix_tree_dynamic', default=False)} "
+                f"alloc={alloc:.3f}GB peak={peak:.3f}GB",
+                flush=True,
+            )
+
+        _mem_log("enter")
+
+        # dynamic prefix-tree opt-in flag (passed via non-tensor data on the micro-batch).
+        use_prefix_tree_dynamic = tu.get_non_tensor_data(data=micro_batch, key="use_prefix_tree_dynamic", default=False)
+        prefix_tree_attention = tu.get_non_tensor_data(data=micro_batch, key="prefix_tree_attention", default="magi")
+        if use_prefix_tree_dynamic and prefix_tree_attention != "magi":
+            raise ValueError(
+                f"prefix_tree_attention={prefix_tree_attention!r} is unsupported on FSDP; "
+                "only 'magi' is supported (flex was retired due to the AReaL 8x entropy bug)."
+            )
+
         # Honor mixed_precision.param_dtype resolved during FSDP setup. When dtype is fp32,
         # autocast is a no-op at best and a footgun at worst, so skip it entirely.
         # getattr fallback: some subclasses (e.g. VeOmniEngine) bypass FSDPEngine.__init__
@@ -1219,10 +1321,112 @@ class FSDPEngineWithLMHead(FSDPEngine):
             else torch.autocast(device_type=device_name, dtype=autocast_dtype)
         )
         with autocast_ctx:
-            raw_output = self.module(
-                **model_inputs,
-                use_cache=False,
-            )  # prevent model thinks we are generating
+            pt_batch = None
+            tree_metrics: dict[str, float] = {}
+            if use_prefix_tree_dynamic:
+                # Defense-in-depth: _build_module already asserts strategy=fsdp2,
+                # but re-check in forward_step in case a code path constructs the
+                # engine without going through _build_module's dynamic-trie setup.
+                assert self.engine_config.strategy == "fsdp2", (
+                    f"use_prefix_tree_dynamic=True requires engine.strategy='fsdp2'; "
+                    f"got strategy='{self.engine_config.strategy}'. "
+                    "FSDP1 + Magi attention is unsupported."
+                )
+
+                # Build prefix-tree micro-batch + Magi key. Returns None on no
+                # shared prefix → transparently fall back to the dense path below.
+                # Magi CP and Ulysses SP are mutually exclusive.
+                assert not self.use_ulysses_sp, (
+                    "use_prefix_tree_dynamic + Magi conflicts with Ulysses SP; "
+                    "set actor.ulysses_sequence_parallel_size=1."
+                )
+                from verl.utils.prefix_tree_magi import build_prefix_tree_micro_batch, restore_flat_to_nested
+
+                # pass loss_mask=None: in RL flow it's response-only and we
+                # read loss_mask off the original micro_batch downstream anyway.
+                _mem_log("before_pt_batch_build")
+                pt_batch = build_prefix_tree_micro_batch(
+                    self.module,
+                    micro_batch["input_ids"],
+                    loss_mask=None,
+                    position_ids=micro_batch.get("position_ids", None),
+                    attention_type="magi",
+                    tp_size=1,
+                    cp_size=self.context_parallel_size,
+                    dynamic_trie=True,
+                )
+                _mem_log("after_pt_batch_build")
+
+                # Tree-dedup metrics: ratio<1 means tokens saved; ratio==1 means
+                # we fell back to dense.
+                _nested = micro_batch["input_ids"]
+                if hasattr(_nested, "values"):
+                    _orig = int(_nested.values().shape[0])
+                else:
+                    _orig = int(sum(int(s.shape[0]) for s in _nested))
+                _packed = int(pt_batch.real_tokens) if pt_batch is not None else _orig
+                tree_metrics = {
+                    "prefix_tree/original_tokens": float(_orig),
+                    "prefix_tree/packed_tokens": float(_packed),
+                    "prefix_tree/token_ratio": float(_packed) / max(float(_orig), 1.0),
+                    "prefix_tree/tokens_saved": float(_orig - _packed),
+                    "prefix_tree/fell_back_to_dense": 1.0 if pt_batch is None else 0.0,
+                }
+
+            if pt_batch is not None:
+                # Magi packed forward. Key is attached per attention module via
+                # set_magi_attention_key_fsdp (module attribute survives activation
+                # checkpoint recompute; see set_magi_attention_key_fsdp docstring).
+                from verl.models.transformers.monkey_patch import set_magi_attention_key_fsdp
+
+                # Magi dispatch/undispatch operate on flat (seq,) along dim=0.
+                # Pattern matches Magi's examples/transformers/magi_trainer.py.
+                if self.context_parallel_size > 1:
+                    from magi_attention.api import dispatch
+
+                    local_flat_input_ids = dispatch(pt_batch.local_flat_input_ids, pt_batch.magi_key)
+                    local_flat_position_ids = dispatch(pt_batch.local_flat_position_ids, pt_batch.magi_key)
+                else:
+                    local_flat_input_ids = pt_batch.local_flat_input_ids
+                    local_flat_position_ids = pt_batch.local_flat_position_ids
+
+                flat_input_ids = local_flat_input_ids.unsqueeze(0)
+                flat_position_ids = local_flat_position_ids.unsqueeze(0)
+
+                set_magi_attention_key_fsdp(self.module, pt_batch.magi_key)
+                _mem_log("before_magi_forward")
+                raw_output = self.module(
+                    input_ids=flat_input_ids,
+                    attention_mask=None,
+                    position_ids=flat_position_ids,
+                    use_cache=False,
+                )
+                _mem_log("after_magi_forward_packed_logits")
+
+                # Per-rank logits (1, local_seq, V) → full flat (full_seq, V).
+                logits = raw_output.logits
+                if self.context_parallel_size > 1:
+                    from magi_attention.api import undispatch
+
+                    logits = undispatch(logits.squeeze(0), pt_batch.magi_key)
+                else:
+                    logits = logits.squeeze(0)
+                _mem_log("after_squeeze_undispatch")
+
+                # Trim prefix-tree padding → restore per-sample → rmpad layout
+                # so prepare_model_outputs sees the standard shape.
+                flat_logits = logits[: pt_batch.real_tokens]
+                _mem_log("after_trim_to_real_tokens")
+                nested_logits = restore_flat_to_nested(flat_logits, pt_batch)
+                _mem_log("after_restore_to_nested")
+                raw_output.logits = nested_logits.values().unsqueeze(0)
+                _mem_log("after_tree_forward")
+            else:
+                raw_output = self.module(
+                    **model_inputs,
+                    use_cache=False,
+                )  # prevent model thinks we are generating
+                _mem_log("after_dense_forward")
 
             model_output = self.prepare_model_outputs(
                 output=raw_output, output_args=output_args, micro_batch=micro_batch, logits_processor_func=loss_function
@@ -1237,12 +1441,18 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 loss = torch.tensor(1.0, device=device_name)
                 metrics = {}
 
+            # Merge in tree-dedup visibility metrics so they roll up alongside
+            # actor/* and perf/* in the per-step training log + wandb.
+            if tree_metrics:
+                metrics.update(tree_metrics)
+
             output = {
                 "model_output": model_output,
                 "loss": loss.detach().item(),
                 "metrics": metrics,
             }
 
+            _mem_log("before_return")
             return loss, output
 
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -42,7 +42,11 @@ from verl.utils.megatron.router_replay_utils import (
     reorder_and_merge_vpp_layers,
     set_router_replay_data,
 )
-from verl.utils.megatron.tensor_parallel import vocab_parallel_entropy, vocab_parallel_log_probs_from_logits
+from verl.utils.megatron.tensor_parallel import (
+    vocab_parallel_entropy,
+    vocab_parallel_log_probs_from_logits,
+    vocab_parallel_sum_pi_squared,
+)
 from verl.utils.megatron_peft_utils import add_base_layer_suffix, build_peft_config_for_vllm
 from verl.utils.megatron_utils import (
     check_mtp_config,
@@ -272,6 +276,7 @@ class MegatronEngine(BaseEngine):
             is_value_model=self.is_value_model,
             wrap_with_ddp=wrap_with_ddp,
             use_distributed_optimizer=self.engine_config.use_distributed_optimizer,
+            use_megatron_fsdp=self.engine_config.use_megatron_fsdp,
         )
         if self.is_value_model:
             self.model_config.hf_config.tie_word_embeddings = False
@@ -425,6 +430,7 @@ class MegatronEngine(BaseEngine):
             provider=self.provider,
             peft_cls=self.peft_cls,
             use_dist_checkpointing=self.engine_config.use_dist_checkpointing,
+            use_megatron_fsdp=self.engine_config.use_megatron_fsdp,
         )
 
         self.to(
@@ -820,7 +826,25 @@ class MegatronEngineWithLMHead(MegatronEngine):
         batch = batch.to(get_device_id())
         use_fused_kernels = tu.get_non_tensor_data(batch, key="use_fused_kernels", default=False)
         calculate_entropy = tu.get_non_tensor_data(batch, key="calculate_entropy", default=False)
+        calculate_sum_pi_squared = tu.get_non_tensor_data(batch, key="calculate_sum_pi_squared", default=False)
         distillation_use_topk = tu.get_non_tensor_data(batch, key="distillation_use_topk", default=False)
+        use_prefix_tree = tu.get_non_tensor_data(batch, key="use_prefix_tree", default=False)
+        prefix_tree_attention = tu.get_non_tensor_data(batch, key="prefix_tree_attention", default="flex")
+        if use_prefix_tree:
+            assert self.engine_config.use_remove_padding, (
+                "use_prefix_tree=True requires use_remove_padding=True (THD format). "
+                "Set model.use_remove_padding=True in your config."
+            )
+            assert prefix_tree_attention in ("flex", "magi"), (
+                f"prefix_tree_attention must be 'flex' or 'magi', got {prefix_tree_attention!r}"
+            )
+        prefix_segments_batch = tu.get_non_tensor_data(batch, key="prefix_segments", default=None)
+
+        if calculate_sum_pi_squared and use_fused_kernels:
+            raise NotImplementedError(
+                "calculate_sum_pi_squared=True is not supported with use_fused_kernels=True: "
+                "fused kernels do not materialize the full logits tensor needed for Σπ²."
+            )
         pad_mode = tu.get_non_tensor_data(batch, key="pad_mode", default=DatasetPadMode.NO_PADDING)
         temperature = batch["temperature"]
         model_inputs = self.prepare_model_inputs(batch)
@@ -898,6 +922,9 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 assert torch.all(temperature > 0).item(), f"temperature tensor must be positive. Got {temperature}"
                 logits.div_(temperature.unsqueeze(dim=-1).to(logits.dtype))
                 ret = {}
+                # sum_pi_squared is non-destructive — must run before vocab_parallel_entropy.
+                if calculate_sum_pi_squared:
+                    ret["sum_pi_squared"] = vocab_parallel_sum_pi_squared(logits)
                 if calculate_entropy:
                     logits_bak = logits.clone()
                     # # disable the hint until the fused_kernel is optimized for triton>=3.3
@@ -919,17 +946,6 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 ret["log_probs"] = log_probs
                 return ret
 
-            use_prefix_tree = tu.get_non_tensor_data(batch, key="use_prefix_tree", default=False)
-            prefix_tree_attention = tu.get_non_tensor_data(batch, key="prefix_tree_attention", default="flex")
-            if use_prefix_tree:
-                assert self.engine_config.use_remove_padding, (
-                    "use_prefix_tree=True requires use_remove_padding=True (THD format). "
-                    "Set model.use_remove_padding=True in your config."
-                )
-                assert prefix_tree_attention in ("flex", "magi"), (
-                    f"prefix_tree_attention must be 'flex' or 'magi', got {prefix_tree_attention!r}"
-                )
-            prefix_segments_batch = tu.get_non_tensor_data(batch, key="prefix_segments", default=None)
             logits_processor_args = {
                 "label": label,
                 "temperature": temperature,
@@ -938,13 +954,6 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 "prefix_tree_attention": prefix_tree_attention,
                 "prefix_segments_batch": prefix_segments_batch,
             }
-
-            # COMPARE_LAYERS: reset capture state before each forward
-            import os as _os
-            if _os.environ.get('COMPARE_LAYERS') == '1':
-                import verl.models.mcore.prefix_tree_merge as _mp
-                _mp._layer_capture.clear()
-                _mp._layer_counter[0] = 0
 
             output = forward_fn(
                 model,
@@ -958,12 +967,6 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 mtp_enable_train=self.model_config.mtp.enable and self.model_config.mtp.enable_train,
                 local_cp_size=local_cp_size,
             )
-
-        # COMPARE_LAYERS: reset layer counter for next forward (save happens in engine_workers after bwd)
-        import os as _os
-        if _os.environ.get('COMPARE_LAYERS') == '1':
-            import verl.models.mcore.prefix_tree_merge as _mp
-            _mp._layer_counter[0] = 0
 
         # Router replay: record routing decisions for R2 mode
         if RouterReplayHelper.is_r2_record_action(self.tf_config, vp_rank):

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -248,9 +248,12 @@ class LLMServerManager:
 
         # for recipe to change
         if not hasattr(self, "rollout_replica_class"):
+            # disaggregation may be absent on older rollout schemas.
+            _disagg = getattr(self.rollout_config, "disaggregation", None)
+            _disagg_enabled = bool(getattr(_disagg, "enabled", False)) if _disagg is not None else False
             self.rollout_replica_class = get_rollout_replica_class(
                 self.rollout_config.name,
-                disaggregation_enabled=self.rollout_config.disaggregation.enabled,
+                disaggregation_enabled=_disagg_enabled,
             )
 
     @classmethod


### PR DESCRIPTION
Brings the dynamic-trie prefix-tree path online for the FSDP backend. Megatron path already shipped via #57; this PR adds the matching FSDP2 wiring, the HF model integration, and the dev / convergence scripts used to validate it.

Why FSDP only: the MagiAttention torch_native example only validates FSDP2 (FSDP1 produces EVAL/TRAIN forward divergence — ppo_kl ≈ 3 plus intermittent NaN grads when combined with Magi). flex_attention path is retired due to the AReaL 8x entropy bug.

Code changes
------------
* verl/workers/engine/fsdp/transformer_impl.py: FSDPEngine forward routes shared-prefix micro-batches through prefix_tree_dynamic_forward (CP-aware Magi dispatch / undispatch, attention-module cp_group attach, gradient flow through restore_flat_to_nested). Fallback to dense forward when no shared prefix is detected.
* verl/models/transformers/monkey_patch.py: register "Magi_Attention" into HF's ALL_ATTENTION_FUNCTIONS so each attention layer dispatches through Magi's FFA kernel. Key is threaded via per-attention-module attribute (_verl_magi_attention_key), set by set_magi_attention_key(model, key) on every forward — same pattern verl already uses for cp_group, survives activation-checkpoint recompute.
* verl/utils/prefix_tree_dynamic.py: add FSDP-side entry points build_prefix_tree_micro_batch_dynamic + prefix_tree_dynamic_forward (thin wrappers over the unified dispatcher with dynamic_trie=True).
* verl/workers/config/{actor,engine}.py + actor.yaml + ref.yaml + generated yamls: new fields use_prefix_tree_dynamic, prefix_tree_attention, context_parallel_size.
* verl/workers/engine_workers.py: thread the new fields through the TrainingWorker engine config for actor + ref.
* verl/trainer/ppo/ray_trainer.py: balance_batch preserves uid grouping for tree training (same condition as PrefixGrouper) — otherwise shared-prefix detection within a micro-batch degrades to chat-template overlap.
* verl/experimental/agent_loop/agent_loop.py + verl/workers/rollout/llm_server.py: defensive getattr for older rollout schemas that don't define function_tool_path / disaggregation.

Dev / convergence scripts (prefix_script/fsdp/, all new) --------------------------------------------------------
* sanity_dynamic_magi.py / sanity_dynamic_magi_cp.py: end-to-end sanity that dynamic-trie + Magi output matches dense baseline within bf16 noise, including CP>1 under LRU pollution.
* profile_tree_memory.py + run_memlog_diag.sh: per-tensor memory profile of tree vs dense forward, including LRU accumulation modes.
* run_e2e_convergence.sh / run_tree_only.sh / run_dense_only.sh / inspect_convergence.py / compare_training_metrics.py: paired tree-vs-dense GRPO convergence runner + per-step metric inspector.
* run_grpo_dynamic_prefix_tree.sh: single-config GRPO launcher.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
